### PR TITLE
Add touch variant of Solo USB C Tap.

### DIFF
--- a/solo/USB-C-touch.brd
+++ b/solo/USB-C-touch.brd
@@ -1,0 +1,2307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.5.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.01" unitdist="mm" unit="mm" style="lines" multiple="1" display="no" altdistance="0.05" altunitdist="mm" altunit="mm"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="yes" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="yes" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="yes" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="yes" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="yes" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="yes" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="no"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="no" active="no"/>
+<layer number="95" name="Names" color="7" fill="1" visible="no" active="no"/>
+<layer number="96" name="Values" color="7" fill="1" visible="no" active="no"/>
+<layer number="97" name="Info" color="7" fill="1" visible="no" active="no"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="yes" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="yes" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="113" name="IDFDebug" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
+</layers>
+<board>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYjdlZTY2" projecturn="a.cGVyc29uYWw6dWUyYjdlZTY2IzIwMTgwNDI5MTI5NzYxOTgx" f3durn="urn:adsk.wipprod:dm.lineage:weNIOFNJQ7WQdbs-7Cwz6Q" pcbguid="f3b1db15-27e8-4af3-8bdd-a250920546ab" lastpulledtime="2018-08-19T19:01:10Z" lastsyncedchangeguid="775ce125-aa76-be61-257a-77efd7f2d611"/>
+<plain>
+<text x="31.99" y="39.43" size="1.4224" layer="21" ratio="15">Solo</text>
+<hole x="37.25" y="49.44" drill="0.5"/>
+<text x="24.96" y="54.1" size="1.4224" layer="21" ratio="15">v2.2-HFA</text>
+<hole x="32.75" y="44.19" drill="0.5"/>
+<wire x1="71.63" y1="51.04" x2="54.53" y2="51.04" width="0.152" layer="49"/>
+<wire x1="54.53" y1="51.04" x2="54.53" y2="40.04" width="0.152" layer="49"/>
+<wire x1="54.53" y1="40.04" x2="71.63" y2="40.04" width="0.152" layer="49"/>
+<wire x1="40.93" y1="45.321" x2="77.413" y2="45.242" width="0.2" layer="49"/>
+<wire x1="42.22273125" y1="54.995790625" x2="39" y2="54.995790625" width="0.1" layer="20"/>
+<wire x1="39" y1="54.995790625" x2="37.5" y2="56.5" width="0.1" layer="20" curve="-60"/>
+<wire x1="37.5" y1="56.5" x2="36" y2="58" width="0.1" layer="20" curve="60"/>
+<wire x1="36" y1="58" x2="26" y2="58" width="0.1" layer="20"/>
+<wire x1="26" y1="58" x2="24.5" y2="56.5" width="0.1" layer="20" curve="45"/>
+<wire x1="24.5" y1="56.5" x2="23" y2="54.995790625" width="0.1" layer="20" curve="-45"/>
+<wire x1="23" y1="54.995790625" x2="15.72273125" y2="54.995790625" width="0.1" layer="20"/>
+<wire x1="15.72273125" y1="54.995790625" x2="15.22273125" y2="54.495790625" width="0.1" layer="20" curve="90"/>
+<wire x1="15.22273125" y1="54.495790625" x2="15.22273125" y2="51.395790625" width="0.1" layer="20"/>
+<wire x1="15.22273125" y1="51.395790625" x2="17.02273125" y2="51.395790625" width="0.1" layer="20"/>
+<wire x1="17.02273125" y1="51.395790625" x2="17.82273125" y2="51.395790625" width="0.1" layer="20" curve="-180"/>
+<wire x1="17.82273125" y1="51.395790625" x2="17.82273125" y2="47.945790625" width="0.1" layer="20"/>
+<wire x1="17.82273125" y1="47.945790625" x2="17.52273125" y2="47.645790625" width="0.1" layer="20" curve="-90"/>
+<wire x1="17.52273125" y1="47.645790625" x2="16.62273125" y2="47.645790625" width="0.1" layer="20"/>
+<wire x1="16.62273125" y1="47.645790625" x2="16.62273125" y2="46.345790625" width="0.1" layer="20"/>
+<wire x1="16.62273125" y1="46.345790625" x2="17.52273125" y2="46.345790625" width="0.1" layer="20"/>
+<wire x1="17.52273125" y1="46.345790625" x2="17.82273125" y2="46.045790625" width="0.1" layer="20" curve="-90"/>
+<wire x1="17.82273125" y1="46.045790625" x2="17.82273125" y2="42.595790625" width="0.1" layer="20"/>
+<wire x1="17.82273125" y1="42.595790625" x2="17.02273125" y2="42.595790625" width="0.1" layer="20" curve="-180"/>
+<wire x1="17.02273125" y1="42.595790625" x2="15.22273125" y2="42.595790625" width="0.1" layer="20"/>
+<wire x1="15.22273125" y1="42.595790625" x2="15.22273125" y2="39.495790625" width="0.1" layer="20"/>
+<wire x1="15.22273125" y1="39.495790625" x2="15.72273125" y2="38.995790625" width="0.1" layer="20" curve="90"/>
+<wire x1="15.72273125" y1="38.995790625" x2="23" y2="38.995790625" width="0.1" layer="20"/>
+<wire x1="23" y1="38.995790625" x2="24.5" y2="37.5" width="0.1" layer="20" curve="-60"/>
+<wire x1="24.5" y1="37.5" x2="26" y2="36" width="0.1" layer="20" curve="60"/>
+<wire x1="26" y1="36" x2="36" y2="36" width="0.1" layer="20"/>
+<wire x1="36" y1="36" x2="37.5" y2="37.5" width="0.1" layer="20" curve="60"/>
+<wire x1="37.5" y1="37.5" x2="39" y2="38.995790625" width="0.1" layer="20" curve="-60"/>
+<wire x1="39" y1="38.995790625" x2="42.22273125" y2="38.995790625" width="0.1" layer="20"/>
+<wire x1="42.22273125" y1="38.995790625" x2="46.22273125" y2="42.995790625" width="0.1" layer="20" curve="90"/>
+<circle x="41.97273125" y="46.995790625" radius="2.125" width="0.1" layer="20"/>
+<wire x1="46.22273125" y1="42.995790625" x2="46.22273125" y2="50.995790625" width="0.1" layer="20"/>
+<wire x1="46.22273125" y1="50.995790625" x2="42.22273125" y2="54.995790625" width="0.1" layer="20" curve="90"/>
+</plain>
+<libraries>
+<library name="efm-fido" urn="urn:adsk.eagle:library:4245354">
+<packages>
+<package name="R0402" urn="urn:adsk.eagle:footprint:4245803/6" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;RESISTOR&lt;/b&gt;</description>
+<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.1524" layer="51"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.1524" layer="51"/>
+<wire x1="-1.073" y1="0.383" x2="1.073" y2="0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="0.383" x2="1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="-0.383" x2="-1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="-1.073" y1="-0.383" x2="-1.073" y2="0.383" width="0.0508" layer="39"/>
+<smd name="1" x="-0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<smd name="2" x="0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<text x="-0.635" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
+<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<rectangle x1="-0.9" y1="-0.35" x2="-0.35" y2="0.35" layer="29"/>
+<rectangle x1="0.35" y1="-0.35" x2="0.9" y2="0.35" layer="29"/>
+</package>
+<package name="B1,27" urn="urn:adsk.eagle:footprint:27900/1" library_version="2" library_locally_modified="yes">
+<description>&lt;b&gt;TEST PAD&lt;/b&gt;</description>
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.0024" layer="37"/>
+<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.0024" layer="37"/>
+<smd name="TP" x="0" y="0" dx="1.27" dy="1.27" layer="1" roundness="100" cream="no"/>
+<text x="-0.635" y="1.016" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-0.635" y="-0.762" size="0.0254" layer="27">&gt;VALUE</text>
+<text x="-0.635" y="-1.905" size="1" layer="37">&gt;TP_SIGNAL_NAME</text>
+</package>
+<package name="C0402" urn="urn:adsk.eagle:footprint:4894774/5" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;CAPACITOR&lt;/b&gt;</description>
+<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.1524" layer="51"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.1524" layer="51"/>
+<wire x1="-1.073" y1="0.383" x2="1.073" y2="0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="0.383" x2="1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="-0.383" x2="-1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="-1.073" y1="-0.383" x2="-1.073" y2="0.383" width="0.0508" layer="39"/>
+<smd name="1" x="-0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<smd name="2" x="0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<text x="-0.635" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
+<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+<rectangle x1="-0.9" y1="-0.35" x2="-0.35" y2="0.35" layer="29"/>
+<rectangle x1="0.35" y1="-0.35" x2="0.9" y2="0.35" layer="29"/>
+</package>
+<package name="QFN32" urn="urn:adsk.eagle:footprint:6434393/5" library_version="82">
+<description>&lt;b&gt;QFN 32&lt;/b&gt; 5 x 5 mm&lt;p&gt;
+Source: http://datasheets.maxim-ic.com/en/ds/MAX7042.pdf</description>
+<wire x1="-2.45" y1="2.45" x2="2.45" y2="2.45" width="0.1016" layer="51"/>
+<wire x1="2.45" y1="2.45" x2="2.45" y2="-2.45" width="0.1016" layer="51"/>
+<wire x1="2.45" y1="-2.45" x2="-2.45" y2="-2.45" width="0.1016" layer="51"/>
+<wire x1="-2.45" y1="-2.45" x2="-2.45" y2="2.45" width="0.1016" layer="51"/>
+<wire x1="-2.45" y1="2.05" x2="-2.45" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="-2.45" y1="2.45" x2="-2.05" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="2.05" y1="2.45" x2="2.45" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="2.45" x2="2.45" y2="2.05" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="-2.05" x2="2.45" y2="-2.45" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="-2.45" x2="2.05" y2="-2.45" width="0.1016" layer="21"/>
+<wire x1="-2.05" y1="-2.45" x2="-2.45" y2="-2.4" width="0.1016" layer="21"/>
+<wire x1="-2.45" y1="-2.4" x2="-2.45" y2="-2.05" width="0.1016" layer="21"/>
+<circle x="-2.425" y="2.475" radius="0.3" width="0" layer="21"/>
+<smd name="EXP" x="0" y="0" dx="0.2" dy="0.2" layer="1" roundness="20" stop="no" cream="no"/>
+<smd name="1" x="-2.35" y="1.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="2" x="-2.35" y="1.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="3" x="-2.35" y="0.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="4" x="-2.35" y="0.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="5" x="-2.35" y="-0.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="6" x="-2.35" y="-0.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="7" x="-2.35" y="-1.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="8" x="-2.35" y="-1.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="9" x="-1.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="10" x="-1.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="11" x="-0.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="12" x="-0.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="13" x="0.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="14" x="0.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="15" x="1.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="16" x="1.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="17" x="2.35" y="-1.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="18" x="2.35" y="-1.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="19" x="2.35" y="-0.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="20" x="2.35" y="-0.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="21" x="2.35" y="0.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="22" x="2.35" y="0.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="23" x="2.35" y="1.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="24" x="2.35" y="1.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="25" x="1.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="26" x="1.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="27" x="0.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="28" x="0.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="29" x="-0.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="30" x="-0.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="31" x="-1.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="32" x="-1.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<text x="-4.05" y="-4.35" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.8" y="3.25" size="1.27" layer="25">&gt;NAME</text>
+<rectangle x1="-0.3" y1="1.1" x2="0.3" y2="1.4" layer="31"/>
+<rectangle x1="-0.3" y1="0.6" x2="0.3" y2="0.9" layer="31"/>
+<rectangle x1="-0.3" y1="0.1" x2="0.3" y2="0.4" layer="31"/>
+<rectangle x1="-0.3" y1="-0.4" x2="0.3" y2="-0.1" layer="31"/>
+<rectangle x1="-0.3" y1="-0.9" x2="0.3" y2="-0.6" layer="31"/>
+<rectangle x1="-0.3" y1="-1.4" x2="0.3" y2="-1.1" layer="31"/>
+<rectangle x1="-1.3" y1="1.1" x2="-0.7" y2="1.4" layer="31"/>
+<rectangle x1="-1.3" y1="0.6" x2="-0.7" y2="0.9" layer="31"/>
+<rectangle x1="-1.3" y1="0.1" x2="-0.7" y2="0.4" layer="31"/>
+<rectangle x1="-1.3" y1="-0.4" x2="-0.7" y2="-0.1" layer="31"/>
+<rectangle x1="-1.3" y1="-0.9" x2="-0.7" y2="-0.6" layer="31"/>
+<rectangle x1="-1.3" y1="-1.4" x2="-0.7" y2="-1.1" layer="31"/>
+<rectangle x1="0.7" y1="1.1" x2="1.3" y2="1.4" layer="31"/>
+<rectangle x1="0.7" y1="0.6" x2="1.3" y2="0.9" layer="31"/>
+<rectangle x1="0.7" y1="0.1" x2="1.3" y2="0.4" layer="31"/>
+<rectangle x1="0.7" y1="-0.4" x2="1.3" y2="-0.1" layer="31"/>
+<rectangle x1="0.7" y1="-0.9" x2="1.3" y2="-0.6" layer="31"/>
+<rectangle x1="0.7" y1="-1.4" x2="1.3" y2="-1.1" layer="31"/>
+<rectangle x1="-2.55" y1="0.3" x2="-0.3" y2="2.55" layer="51"/>
+<rectangle x1="-0.3" y1="1.1" x2="0.3" y2="1.4" layer="1"/>
+<rectangle x1="-0.3" y1="0.6" x2="0.3" y2="0.9" layer="1"/>
+<rectangle x1="-0.3" y1="0.1" x2="0.3" y2="0.4" layer="1"/>
+<rectangle x1="-0.3" y1="-0.4" x2="0.3" y2="-0.1" layer="1"/>
+<rectangle x1="-0.3" y1="-0.9" x2="0.3" y2="-0.6" layer="1"/>
+<rectangle x1="-0.3" y1="-1.4" x2="0.3" y2="-1.1" layer="1"/>
+<rectangle x1="-1.3" y1="1.1" x2="-0.7" y2="1.4" layer="1"/>
+<rectangle x1="-1.3" y1="0.6" x2="-0.7" y2="0.9" layer="1"/>
+<rectangle x1="-1.3" y1="0.1" x2="-0.7" y2="0.4" layer="1"/>
+<rectangle x1="-1.3" y1="-0.4" x2="-0.7" y2="-0.1" layer="1"/>
+<rectangle x1="-1.3" y1="-0.9" x2="-0.7" y2="-0.6" layer="1"/>
+<rectangle x1="-1.3" y1="-1.4" x2="-0.7" y2="-1.1" layer="1"/>
+<rectangle x1="0.7" y1="1.1" x2="1.3" y2="1.4" layer="1"/>
+<rectangle x1="0.7" y1="0.6" x2="1.3" y2="0.9" layer="1"/>
+<rectangle x1="0.7" y1="0.1" x2="1.3" y2="0.4" layer="1"/>
+<rectangle x1="0.7" y1="-0.4" x2="1.3" y2="-0.1" layer="1"/>
+<rectangle x1="0.7" y1="-0.9" x2="1.3" y2="-0.6" layer="1"/>
+<rectangle x1="0.7" y1="-1.4" x2="1.3" y2="-1.1" layer="1"/>
+<polygon width="0.5" layer="29">
+<vertex x="-1.325" y="1.175"/>
+<vertex x="-1.175" y="1.325"/>
+<vertex x="1.325" y="1.325"/>
+<vertex x="1.325" y="-1.325"/>
+<vertex x="-1.325" y="-1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="1.85"/>
+<vertex x="-2.1" y="1.85"/>
+<vertex x="-2.05" y="1.8"/>
+<vertex x="-2.05" y="1.65"/>
+<vertex x="-2.55" y="1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="1.825"/>
+<vertex x="-2.175" y="1.825"/>
+<vertex x="-2.125" y="1.775"/>
+<vertex x="-2.125" y="1.675"/>
+<vertex x="-2.575" y="1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="1.35"/>
+<vertex x="-2.05" y="1.35"/>
+<vertex x="-2.05" y="1.15"/>
+<vertex x="-2.55" y="1.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="1.325"/>
+<vertex x="-2.125" y="1.325"/>
+<vertex x="-2.125" y="1.175"/>
+<vertex x="-2.575" y="1.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="0.85"/>
+<vertex x="-2.05" y="0.85"/>
+<vertex x="-2.05" y="0.65"/>
+<vertex x="-2.55" y="0.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="0.825"/>
+<vertex x="-2.125" y="0.825"/>
+<vertex x="-2.125" y="0.675"/>
+<vertex x="-2.575" y="0.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="0.35"/>
+<vertex x="-2.05" y="0.35"/>
+<vertex x="-2.05" y="0.15"/>
+<vertex x="-2.55" y="0.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="0.325"/>
+<vertex x="-2.125" y="0.325"/>
+<vertex x="-2.125" y="0.175"/>
+<vertex x="-2.575" y="0.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-0.15"/>
+<vertex x="-2.05" y="-0.15"/>
+<vertex x="-2.05" y="-0.35"/>
+<vertex x="-2.55" y="-0.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-0.175"/>
+<vertex x="-2.125" y="-0.175"/>
+<vertex x="-2.125" y="-0.325"/>
+<vertex x="-2.575" y="-0.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-0.65"/>
+<vertex x="-2.05" y="-0.65"/>
+<vertex x="-2.05" y="-0.85"/>
+<vertex x="-2.55" y="-0.85"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-0.675"/>
+<vertex x="-2.125" y="-0.675"/>
+<vertex x="-2.125" y="-0.825"/>
+<vertex x="-2.575" y="-0.825"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-1.15"/>
+<vertex x="-2.05" y="-1.15"/>
+<vertex x="-2.05" y="-1.35"/>
+<vertex x="-2.55" y="-1.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-1.175"/>
+<vertex x="-2.125" y="-1.175"/>
+<vertex x="-2.125" y="-1.325"/>
+<vertex x="-2.575" y="-1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-1.85"/>
+<vertex x="-2.1" y="-1.85"/>
+<vertex x="-2.05" y="-1.8"/>
+<vertex x="-2.05" y="-1.65"/>
+<vertex x="-2.55" y="-1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-1.825"/>
+<vertex x="-2.175" y="-1.825"/>
+<vertex x="-2.125" y="-1.775"/>
+<vertex x="-2.125" y="-1.675"/>
+<vertex x="-2.575" y="-1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.85" y="-2.55"/>
+<vertex x="-1.85" y="-2.1"/>
+<vertex x="-1.8" y="-2.05"/>
+<vertex x="-1.65" y="-2.05"/>
+<vertex x="-1.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.825" y="-2.575"/>
+<vertex x="-1.825" y="-2.175"/>
+<vertex x="-1.775" y="-2.125"/>
+<vertex x="-1.675" y="-2.125"/>
+<vertex x="-1.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.35" y="-2.55"/>
+<vertex x="-1.35" y="-2.05"/>
+<vertex x="-1.15" y="-2.05"/>
+<vertex x="-1.15" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.325" y="-2.575"/>
+<vertex x="-1.325" y="-2.125"/>
+<vertex x="-1.175" y="-2.125"/>
+<vertex x="-1.175" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.85" y="-2.55"/>
+<vertex x="-0.85" y="-2.05"/>
+<vertex x="-0.65" y="-2.05"/>
+<vertex x="-0.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.825" y="-2.575"/>
+<vertex x="-0.825" y="-2.125"/>
+<vertex x="-0.675" y="-2.125"/>
+<vertex x="-0.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.35" y="-2.55"/>
+<vertex x="-0.35" y="-2.05"/>
+<vertex x="-0.15" y="-2.05"/>
+<vertex x="-0.15" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.325" y="-2.575"/>
+<vertex x="-0.325" y="-2.125"/>
+<vertex x="-0.175" y="-2.125"/>
+<vertex x="-0.175" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.15" y="-2.55"/>
+<vertex x="0.15" y="-2.05"/>
+<vertex x="0.35" y="-2.05"/>
+<vertex x="0.35" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.175" y="-2.575"/>
+<vertex x="0.175" y="-2.125"/>
+<vertex x="0.325" y="-2.125"/>
+<vertex x="0.325" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.65" y="-2.55"/>
+<vertex x="0.65" y="-2.05"/>
+<vertex x="0.85" y="-2.05"/>
+<vertex x="0.85" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.675" y="-2.575"/>
+<vertex x="0.675" y="-2.125"/>
+<vertex x="0.825" y="-2.125"/>
+<vertex x="0.825" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.15" y="-2.55"/>
+<vertex x="1.15" y="-2.05"/>
+<vertex x="1.35" y="-2.05"/>
+<vertex x="1.35" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.175" y="-2.575"/>
+<vertex x="1.175" y="-2.125"/>
+<vertex x="1.325" y="-2.125"/>
+<vertex x="1.325" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.85" y="-2.55"/>
+<vertex x="1.85" y="-2.1"/>
+<vertex x="1.8" y="-2.05"/>
+<vertex x="1.65" y="-2.05"/>
+<vertex x="1.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.825" y="-2.575"/>
+<vertex x="1.825" y="-2.175"/>
+<vertex x="1.775" y="-2.125"/>
+<vertex x="1.675" y="-2.125"/>
+<vertex x="1.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-1.85"/>
+<vertex x="2.1" y="-1.85"/>
+<vertex x="2.05" y="-1.8"/>
+<vertex x="2.05" y="-1.65"/>
+<vertex x="2.55" y="-1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-1.825"/>
+<vertex x="2.175" y="-1.825"/>
+<vertex x="2.125" y="-1.775"/>
+<vertex x="2.125" y="-1.675"/>
+<vertex x="2.575" y="-1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-1.35"/>
+<vertex x="2.05" y="-1.35"/>
+<vertex x="2.05" y="-1.15"/>
+<vertex x="2.55" y="-1.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-1.325"/>
+<vertex x="2.125" y="-1.325"/>
+<vertex x="2.125" y="-1.175"/>
+<vertex x="2.575" y="-1.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-0.85"/>
+<vertex x="2.05" y="-0.85"/>
+<vertex x="2.05" y="-0.65"/>
+<vertex x="2.55" y="-0.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-0.825"/>
+<vertex x="2.125" y="-0.825"/>
+<vertex x="2.125" y="-0.675"/>
+<vertex x="2.575" y="-0.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-0.35"/>
+<vertex x="2.05" y="-0.35"/>
+<vertex x="2.05" y="-0.15"/>
+<vertex x="2.55" y="-0.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-0.325"/>
+<vertex x="2.125" y="-0.325"/>
+<vertex x="2.125" y="-0.175"/>
+<vertex x="2.575" y="-0.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="0.15"/>
+<vertex x="2.05" y="0.15"/>
+<vertex x="2.05" y="0.35"/>
+<vertex x="2.55" y="0.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="0.175"/>
+<vertex x="2.125" y="0.175"/>
+<vertex x="2.125" y="0.325"/>
+<vertex x="2.575" y="0.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="0.65"/>
+<vertex x="2.05" y="0.65"/>
+<vertex x="2.05" y="0.85"/>
+<vertex x="2.55" y="0.85"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="0.675"/>
+<vertex x="2.125" y="0.675"/>
+<vertex x="2.125" y="0.825"/>
+<vertex x="2.575" y="0.825"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="1.15"/>
+<vertex x="2.05" y="1.15"/>
+<vertex x="2.05" y="1.35"/>
+<vertex x="2.55" y="1.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="1.175"/>
+<vertex x="2.125" y="1.175"/>
+<vertex x="2.125" y="1.325"/>
+<vertex x="2.575" y="1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="1.85"/>
+<vertex x="2.1" y="1.85"/>
+<vertex x="2.05" y="1.8"/>
+<vertex x="2.05" y="1.65"/>
+<vertex x="2.55" y="1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="1.825"/>
+<vertex x="2.175" y="1.825"/>
+<vertex x="2.125" y="1.775"/>
+<vertex x="2.125" y="1.675"/>
+<vertex x="2.575" y="1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.85" y="2.55"/>
+<vertex x="1.85" y="2.1"/>
+<vertex x="1.8" y="2.05"/>
+<vertex x="1.65" y="2.05"/>
+<vertex x="1.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.825" y="2.575"/>
+<vertex x="1.825" y="2.175"/>
+<vertex x="1.775" y="2.125"/>
+<vertex x="1.675" y="2.125"/>
+<vertex x="1.675" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.35" y="2.55"/>
+<vertex x="1.35" y="2.05"/>
+<vertex x="1.15" y="2.05"/>
+<vertex x="1.15" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.325" y="2.575"/>
+<vertex x="1.325" y="2.125"/>
+<vertex x="1.175" y="2.125"/>
+<vertex x="1.175" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.85" y="2.55"/>
+<vertex x="0.85" y="2.05"/>
+<vertex x="0.65" y="2.05"/>
+<vertex x="0.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.825" y="2.575"/>
+<vertex x="0.825" y="2.125"/>
+<vertex x="0.675" y="2.125"/>
+<vertex x="0.675" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.35" y="2.55"/>
+<vertex x="0.35" y="2.05"/>
+<vertex x="0.15" y="2.05"/>
+<vertex x="0.15" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.325" y="2.575"/>
+<vertex x="0.325" y="2.125"/>
+<vertex x="0.175" y="2.125"/>
+<vertex x="0.175" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.15" y="2.55"/>
+<vertex x="-0.15" y="2.05"/>
+<vertex x="-0.35" y="2.05"/>
+<vertex x="-0.35" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.175" y="2.575"/>
+<vertex x="-0.175" y="2.125"/>
+<vertex x="-0.325" y="2.125"/>
+<vertex x="-0.325" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.65" y="2.55"/>
+<vertex x="-0.65" y="2.05"/>
+<vertex x="-0.85" y="2.05"/>
+<vertex x="-0.85" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.675" y="2.575"/>
+<vertex x="-0.675" y="2.125"/>
+<vertex x="-0.825" y="2.125"/>
+<vertex x="-0.825" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.15" y="2.55"/>
+<vertex x="-1.15" y="2.05"/>
+<vertex x="-1.35" y="2.05"/>
+<vertex x="-1.35" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.175" y="2.575"/>
+<vertex x="-1.175" y="2.125"/>
+<vertex x="-1.325" y="2.125"/>
+<vertex x="-1.325" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.85" y="2.55"/>
+<vertex x="-1.85" y="2.1"/>
+<vertex x="-1.8" y="2.05"/>
+<vertex x="-1.65" y="2.05"/>
+<vertex x="-1.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.825" y="2.575"/>
+<vertex x="-1.825" y="2.175"/>
+<vertex x="-1.775" y="2.125"/>
+<vertex x="-1.675" y="2.125"/>
+<vertex x="-1.675" y="2.575"/>
+</polygon>
+<polygon width="0.127" layer="1" spacing="0.7112" pour="hatch">
+<vertex x="-1.5" y="1.5"/>
+<vertex x="1.5" y="1.5"/>
+<vertex x="1.5" y="-1.5"/>
+<vertex x="-1.5" y="-1.5"/>
+</polygon>
+</package>
+<package name="REG_NCP114AMX330TCG" urn="urn:adsk.eagle:footprint:5621085/3" library_version="66">
+<polygon width="0.001" layer="1">
+<vertex x="-0.475" y="0.65"/>
+<vertex x="-0.475" y="0.22"/>
+<vertex x="-0.375" y="0.22"/>
+<vertex x="-0.175" y="0.42"/>
+<vertex x="-0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="0.475" y="0.65"/>
+<vertex x="0.475" y="0.22"/>
+<vertex x="0.375" y="0.22"/>
+<vertex x="0.175" y="0.42"/>
+<vertex x="0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="0.475" y="-0.65"/>
+<vertex x="0.475" y="-0.22"/>
+<vertex x="0.375" y="-0.22"/>
+<vertex x="0.175" y="-0.42"/>
+<vertex x="0.175" y="-0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="-0.475" y="-0.65"/>
+<vertex x="-0.175" y="-0.65"/>
+<vertex x="-0.175" y="-0.42"/>
+<vertex x="-0.475" y="-0.12"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="-0.475" y="0.65"/>
+<vertex x="-0.475" y="0.22"/>
+<vertex x="-0.375" y="0.22"/>
+<vertex x="-0.175" y="0.42"/>
+<vertex x="-0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="0.475" y="0.65"/>
+<vertex x="0.475" y="0.22"/>
+<vertex x="0.375" y="0.22"/>
+<vertex x="0.175" y="0.42"/>
+<vertex x="0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="0.475" y="-0.65"/>
+<vertex x="0.475" y="-0.22"/>
+<vertex x="0.375" y="-0.22"/>
+<vertex x="0.175" y="-0.42"/>
+<vertex x="0.175" y="-0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="-0.475" y="-0.65"/>
+<vertex x="-0.175" y="-0.65"/>
+<vertex x="-0.175" y="-0.42"/>
+<vertex x="-0.475" y="-0.12"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="-0.525" y="0.7"/>
+<vertex x="-0.125" y="0.7"/>
+<vertex x="-0.125" y="0.4"/>
+<vertex x="-0.35" y="0.175"/>
+<vertex x="-0.525" y="0.175"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="0.525" y="-0.7"/>
+<vertex x="0.125" y="-0.7"/>
+<vertex x="0.125" y="-0.4"/>
+<vertex x="0.35" y="-0.175"/>
+<vertex x="0.525" y="-0.175"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="0.125" y="0.7"/>
+<vertex x="0.525" y="0.7"/>
+<vertex x="0.525" y="0.175"/>
+<vertex x="0.35" y="0.175"/>
+<vertex x="0.125" y="0.4"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="-0.525" y="-0.7"/>
+<vertex x="-0.125" y="-0.7"/>
+<vertex x="-0.125" y="-0.4"/>
+<vertex x="-0.475" y="-0.05"/>
+<vertex x="-0.525" y="-0.05"/>
+</polygon>
+<circle x="-0.74" y="-0.848" radius="0.14" width="0.1016" layer="21"/>
+<wire x1="-0.5" y1="0.5" x2="-0.5" y2="-0.5" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.5" x2="0.5" y2="-0.5" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.5" x2="0.5" y2="0.5" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.5" x2="-0.5" y2="0.5" width="0.1" layer="51"/>
+<wire x1="-0.762" y1="0.889" x2="-0.762" y2="-0.889" width="0.05" layer="39"/>
+<wire x1="-0.762" y1="-0.889" x2="0.762" y2="-0.889" width="0.05" layer="39"/>
+<wire x1="0.762" y1="-0.889" x2="0.762" y2="0.889" width="0.05" layer="39"/>
+<wire x1="0.762" y1="0.889" x2="-0.762" y2="0.889" width="0.05" layer="39"/>
+<text x="-0.74228125" y="0.972990625" size="0.6" layer="25">&gt;NAME</text>
+<text x="-0.742921875" y="-1.2449" size="0.306003125" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.351734375" y1="-0.351734375" x2="0.35" y2="0.35" layer="29" rot="R45"/>
+<smd name="5" x="0" y="0" dx="0.58" dy="0.58" layer="1" rot="R45" stop="no"/>
+<smd name="1" x="-0.325" y="-0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="2" x="0.325" y="-0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="3" x="0.325" y="0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="4" x="-0.325" y="0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+</package>
+<package name="BZA900A" urn="urn:adsk.eagle:footprint:5621086/2" library_version="28">
+<smd name="P$1" x="-0.05" y="0" dx="0.325" dy="0.5" layer="1"/>
+<smd name="P$2" x="0.5" y="0" dx="0.3" dy="0.6" layer="1"/>
+<smd name="P$3" x="1.05" y="0" dx="0.325" dy="0.5" layer="1"/>
+<smd name="P$4" x="1" y="1.7" dx="0.4" dy="0.5" layer="1"/>
+<smd name="P$5" x="0" y="1.7" dx="0.4" dy="0.5" layer="1"/>
+<text x="-0.5" y="1.8" size="0.4064" layer="25">&gt;NAME</text>
+</package>
+<package name="MLPD3X3" urn="urn:adsk.eagle:footprint:5825737/8" library_version="82">
+<smd name="P5" x="0" y="-2.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P4" x="0" y="-2.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P3" x="0" y="-1.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P2" x="0" y="-1.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P1" x="0" y="-0.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P10" x="3" y="-0.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P9" x="3" y="-1.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P8" x="3" y="-1.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P7" x="3" y="-2.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P6" x="3" y="-2.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P$11" x="1.6" y="-1.64" dx="0.2" dy="0.2" layer="1" rot="R180"/>
+<text x="-0.5" y="-3.04" size="0.6096" layer="25" rot="R90">&gt;NAME</text>
+<text x="4" y="-3.04" size="0.6096" layer="27" rot="R90">&gt;VALUE</text>
+<polygon width="0.127" layer="1" spacing="0.7366" pour="hatch">
+<vertex x="0.7" y="-0.4"/>
+<vertex x="2.3" y="-0.4"/>
+<vertex x="2.3" y="-2.7"/>
+<vertex x="0.7" y="-2.7"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.7" y="-0.4"/>
+<vertex x="2.3" y="-0.4"/>
+<vertex x="2.3" y="-2.7"/>
+<vertex x="0.7" y="-2.7"/>
+</polygon>
+<circle x="-0.5588" y="0.2286" radius="0.1626375" width="0.3556" layer="25"/>
+<rectangle x1="1.4" y1="-2.6" x2="1.6" y2="-0.5" layer="31"/>
+<rectangle x1="0.7" y1="-0.8" x2="1.3" y2="-0.6" layer="31"/>
+<rectangle x1="1.7" y1="-0.8" x2="2.3" y2="-0.6" layer="31"/>
+<rectangle x1="0.7" y1="-1.6" x2="1.3" y2="-1.3" layer="31"/>
+<rectangle x1="1.8" y1="-1.6" x2="2.3" y2="-1.3" layer="31"/>
+<rectangle x1="0.7" y1="-2.3" x2="1.3" y2="-2.1" layer="31"/>
+<rectangle x1="1.8" y1="-2.3" x2="2.3" y2="-2.1" layer="31"/>
+</package>
+<package name="WüRTH_632712000112" urn="urn:adsk.eagle:footprint:9339181/5" library_version="75">
+<smd name="A12" x="0.154525" y="1.01879375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A11" x="0.65488125" y="1.016203125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A10" x="1.158565625" y="1.023003125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A9" x="1.654875" y="1.0210125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A8" x="2.15640625" y="1.016634375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A7" x="2.654875" y="1.016765625" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A6" x="3.15690625" y="1.021084375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A5" x="3.653228125" y="1.02091875" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A4" x="4.161096875" y="1.020959375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A3" x="4.648653125" y="1.02311875" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A2" x="5.1519375" y="1.0209" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A1" x="5.6505" y="1.01689375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="P_GND3" x="6.353828125" y="1.1464125" dx="0.45" dy="1.45" layer="1" rot="R180"/>
+<smd name="P_GND4" x="-0.523228125" y="1.145934375" dx="0.45" dy="1.45" layer="1" rot="R180"/>
+<smd name="B12" x="5.6464375" y="1.0147875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B11" x="5.15690625" y="1.023171875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B10" x="4.644715625" y="1.020990625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B1" x="0.154653125" y="1.0185625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B2" x="0.65200625" y="1.018671875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B3" x="1.15769375" y="1.023403125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B4" x="1.65549375" y="1.02088125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B5" x="2.155321875" y="1.01668125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B6" x="2.65775" y="1.01414375" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B7" x="3.155375" y="1.02145" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B8" x="3.65476875" y="1.01905625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B9" x="4.1600125" y="1.01905625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="P_GND1" x="-0.523771875" y="1.145934375" dx="0.45" dy="1.45" layer="16"/>
+<smd name="P_GND2" x="6.339828125" y="1.145934375" dx="0.45" dy="1.45" layer="16"/>
+<polygon width="0.025" layer="1">
+<vertex x="-0.23291875" y="0.343890625"/>
+<vertex x="-0.822" y="0.348"/>
+<vertex x="-0.822" y="2.223290625"/>
+<vertex x="-0.23291875" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="0.00508125" y="1.693890625"/>
+<vertex x="0.00508125" y="0.343890625"/>
+<vertex x="0.30508125" y="0.343890625"/>
+<vertex x="0.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="0.50508125" y="1.693890625"/>
+<vertex x="0.50508125" y="0.343890625"/>
+<vertex x="0.80508125" y="0.343890625"/>
+<vertex x="0.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="1.00508125" y="1.693890625"/>
+<vertex x="1.00508125" y="0.343890625"/>
+<vertex x="1.30508125" y="0.343890625"/>
+<vertex x="1.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="1.50508125" y="1.693890625"/>
+<vertex x="1.50508125" y="0.343890625"/>
+<vertex x="1.80508125" y="0.343890625"/>
+<vertex x="1.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="2.00508125" y="1.693890625"/>
+<vertex x="2.00508125" y="0.343890625"/>
+<vertex x="2.30508125" y="0.343890625"/>
+<vertex x="2.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="2.50508125" y="1.693890625"/>
+<vertex x="2.50508125" y="0.343890625"/>
+<vertex x="2.80508125" y="0.343890625"/>
+<vertex x="2.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="3.30508125" y="0.343890625"/>
+<vertex x="3.00508125" y="0.343890625"/>
+<vertex x="3.00508125" y="1.693890625"/>
+<vertex x="3.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="3.80508125" y="0.343890625"/>
+<vertex x="3.50508125" y="0.343890625"/>
+<vertex x="3.50508125" y="1.693890625"/>
+<vertex x="3.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="4.00508125" y="1.693890625"/>
+<vertex x="4.00508125" y="0.343890625"/>
+<vertex x="4.30508125" y="0.343890625"/>
+<vertex x="4.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="4.50508125" y="1.693890625"/>
+<vertex x="4.50508125" y="0.343890625"/>
+<vertex x="4.80508125" y="0.343890625"/>
+<vertex x="4.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="5.30508125" y="0.343890625"/>
+<vertex x="5.00508125" y="0.343890625"/>
+<vertex x="5.00508125" y="1.693890625"/>
+<vertex x="5.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="5.80508125" y="0.343890625"/>
+<vertex x="5.50508125" y="0.343890625"/>
+<vertex x="5.50508125" y="1.693890625"/>
+<vertex x="5.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="6.04308125" y="2.223290625"/>
+<vertex x="6.04308125" y="0.343890625"/>
+<vertex x="6.62448125" y="0.343890625"/>
+<vertex x="6.62448125" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="-0.23291875" y="0.343890625"/>
+<vertex x="-0.81431875" y="0.343890625"/>
+<vertex x="-0.81431875" y="2.223290625"/>
+<vertex x="-0.23291875" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="0.00508125" y="1.693890625"/>
+<vertex x="0.00508125" y="0.343890625"/>
+<vertex x="0.30508125" y="0.343890625"/>
+<vertex x="0.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="0.50508125" y="1.693890625"/>
+<vertex x="0.50508125" y="0.343890625"/>
+<vertex x="0.80508125" y="0.343890625"/>
+<vertex x="0.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="1.00508125" y="1.693890625"/>
+<vertex x="1.00508125" y="0.343890625"/>
+<vertex x="1.30508125" y="0.343890625"/>
+<vertex x="1.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="1.50508125" y="1.693890625"/>
+<vertex x="1.50508125" y="0.343890625"/>
+<vertex x="1.80508125" y="0.343890625"/>
+<vertex x="1.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="2.00508125" y="1.693890625"/>
+<vertex x="2.00508125" y="0.343890625"/>
+<vertex x="2.30508125" y="0.343890625"/>
+<vertex x="2.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="2.50508125" y="1.693890625"/>
+<vertex x="2.50508125" y="0.343890625"/>
+<vertex x="2.80508125" y="0.343890625"/>
+<vertex x="2.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="3.30508125" y="0.343890625"/>
+<vertex x="3.00508125" y="0.343890625"/>
+<vertex x="3.00508125" y="1.693890625"/>
+<vertex x="3.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="3.80508125" y="0.343890625"/>
+<vertex x="3.50508125" y="0.343890625"/>
+<vertex x="3.50508125" y="1.693890625"/>
+<vertex x="3.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="4.00508125" y="1.693890625"/>
+<vertex x="4.00508125" y="0.343890625"/>
+<vertex x="4.30508125" y="0.343890625"/>
+<vertex x="4.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="4.50508125" y="1.693890625"/>
+<vertex x="4.50508125" y="0.343890625"/>
+<vertex x="4.80508125" y="0.343890625"/>
+<vertex x="4.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="5.30508125" y="0.343890625"/>
+<vertex x="5.00508125" y="0.343890625"/>
+<vertex x="5.00508125" y="1.693890625"/>
+<vertex x="5.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="5.80508125" y="0.343890625"/>
+<vertex x="5.50508125" y="0.343890625"/>
+<vertex x="5.50508125" y="1.693890625"/>
+<vertex x="5.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="6.04308125" y="2.223290625"/>
+<vertex x="6.04308125" y="0.343890625"/>
+<vertex x="6.62448125" y="0.343890625"/>
+<vertex x="6.62448125" y="2.223290625"/>
+</polygon>
+<wire x1="-1.34491875" y1="1.918490625" x2="-1.34491875" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="-1.34491875" y1="0.138490625" x2="2.90508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="2.90508125" y1="0.138490625" x2="7.15508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="7.15508125" y1="1.918490625" x2="7.15508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="2.90508125" y1="0.138490625" x2="2.90508125" y2="3.70436875" width="0.025" layer="25"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="1"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="1"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="16"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="16"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="29"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="29"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="30"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="30"/>
+</package>
+<package name="CL-505S-X-SD-T" urn="urn:adsk.eagle:footprint:4878738/6" library_version="79">
+<description>CL-505S-X-SD-T</description>
+<smd name="P$2" x="0.85" y="0.85" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$1" x="0.85" y="0" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$4" x="0" y="0" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$3" x="0" y="0.85" dx="0.4" dy="0.4" layer="1"/>
+<text x="-0.4" y="1.4" size="0.4" layer="21">&gt;NAME</text>
+<circle x="1.2990625" y="1.271121875" radius="0.1" width="0.2032" layer="21"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="R0402" urn="urn:adsk.eagle:package:4245807/8" type="model" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;RESISTOR&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="R0402"/>
+</packageinstances>
+</package3d>
+<package3d name="B1,27" urn="urn:adsk.eagle:package:4245792/4" type="box" library_version="7" library_locally_modified="yes">
+<description>TEST PAD</description>
+<packageinstances>
+<packageinstance name="B1,27"/>
+</packageinstances>
+</package3d>
+<package3d name="C0402" urn="urn:adsk.eagle:package:4245806/9" type="model" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;CAPACITOR&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="C0402"/>
+</packageinstances>
+</package3d>
+<package3d name="QFN50P500X500X50-32" urn="urn:adsk.eagle:package:4245373/9" type="model" library_version="82">
+<description>&lt;b&gt;QFN 32&lt;/b&gt; 5 x 5 mm&lt;p&gt;
+Source: http://datasheets.maxim-ic.com/en/ds/MAX7042.pdf</description>
+<packageinstances>
+<packageinstance name="QFN32"/>
+</packageinstances>
+</package3d>
+<package3d name="DFN100X100X60-4" urn="urn:adsk.eagle:package:5621121/4" type="model" library_version="66">
+<packageinstances>
+<packageinstance name="REG_NCP114AMX330TCG"/>
+</packageinstances>
+</package3d>
+<package3d name="SOTFL50P160X60-5" urn="urn:adsk.eagle:package:5621120/4" type="model" library_version="28">
+<packageinstances>
+<packageinstance name="BZA900A"/>
+</packageinstances>
+</package3d>
+<package3d name="MLPD3X3" urn="urn:adsk.eagle:package:5825738/8" type="box" library_version="82">
+<packageinstances>
+<packageinstance name="MLPD3X3"/>
+</packageinstances>
+</package3d>
+<package3d name="WüRTH_632712000112" urn="urn:adsk.eagle:package:9339182/7" type="model" library_version="75">
+<packageinstances>
+<packageinstance name="WüRTH_632712000112"/>
+</packageinstances>
+</package3d>
+<package3d name="CL-505S-X-SD-T" urn="urn:adsk.eagle:package:4878740/9" type="box" library_version="93" library_locally_modified="yes">
+<description>CL-505S-X-SD-T</description>
+<packageinstances>
+<packageinstance name="CL-505S-X-SD-T"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="ultra_librarian">
+<packages>
+<package name="RC0402N-L">
+<smd name="1" x="-0.456" y="0" dx="0.4548" dy="0.408" layer="1"/>
+<smd name="2" x="0.456" y="0" dx="0.4548" dy="0.408" layer="1"/>
+<wire x1="-0.7874" y1="-0.3048" x2="-0.7874" y2="0.3048" width="0.1524" layer="39"/>
+<wire x1="-0.7874" y1="0.3048" x2="0.7874" y2="0.3048" width="0.1524" layer="39"/>
+<wire x1="0.7874" y1="0.3048" x2="0.7874" y2="-0.3048" width="0.1524" layer="39"/>
+<wire x1="0.7874" y1="-0.3048" x2="-0.7874" y2="-0.3048" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-0.785" y="-0.3056"/>
+<vertex x="-0.785" y="0.3056"/>
+<vertex x="0.785" y="0.3056"/>
+<vertex x="0.785" y="-0.3056"/>
+</polygon>
+<wire x1="-0.2286" y1="-0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="0.254" x2="-0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="-0.254" x2="-0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="-0.254" x2="0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="0.254" x2="0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="-0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="-0.254" x2="0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="0.254" x2="-0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.2032"/>
+<vertex x="0.1778" y="0.2032"/>
+<vertex x="0.1778" y="-0.2032"/>
+<vertex x="-0.1778" y="-0.2032"/>
+</polygon>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+</packages>
+</library>
+<library name="GRM2195C1H103FA01D">
+<packages>
+<package name="CAPC2012X95N">
+<text x="-1.66" y="-1.02" size="0.5" layer="27" align="top-left">&gt;VALUE</text>
+<text x="-1.66" y="1.02" size="0.5" layer="25">&gt;NAME</text>
+<wire x1="1.05" y1="-0.68" x2="-1.05" y2="-0.68" width="0.127" layer="51"/>
+<wire x1="1.05" y1="0.68" x2="-1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="1.05" y1="-0.68" x2="1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="-1.05" y1="-0.68" x2="-1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="-1.665" y1="-0.94" x2="1.665" y2="-0.94" width="0.05" layer="39"/>
+<wire x1="-1.665" y1="0.94" x2="1.665" y2="0.94" width="0.05" layer="39"/>
+<wire x1="-1.665" y1="-0.94" x2="-1.665" y2="0.94" width="0.05" layer="39"/>
+<wire x1="1.665" y1="-0.94" x2="1.665" y2="0.94" width="0.05" layer="39"/>
+<smd name="1" x="-0.888" y="0" dx="1.05" dy="1.38" layer="1"/>
+<smd name="2" x="0.888" y="0" dx="1.05" dy="1.38" layer="1"/>
+</package>
+</packages>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0.1524" drill="0.2032">
+<clearance class="0" value="0.1016"/>
+</class>
+</classes>
+<designrules name="default *">
+<description language="de">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+&lt;p&gt;
+Die Standard-Design-Rules sind so gewählt, dass sie für 
+die meisten Anwendungen passen. Sollte ihre Platine 
+besondere Anforderungen haben, treffen Sie die erforderlichen
+Einstellungen hier und speichern die Design Rules unter 
+einem neuen Namen ab.</description>
+<description language="en">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+&lt;p&gt;
+The default Design Rules have been set to cover
+a wide range of applications. Your particular design
+may have different requirements, so please make the
+necessary adjustments and save your customized
+design rules under a new name.</description>
+<param name="layerSetup" value="(1*16)"/>
+<param name="mtCopper" value="0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm"/>
+<param name="mtIsolate" value="0.8mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm"/>
+<param name="mdWireWire" value="4mil"/>
+<param name="mdWirePad" value="4mil"/>
+<param name="mdWireVia" value="4mil"/>
+<param name="mdPadPad" value="4mil"/>
+<param name="mdPadVia" value="4mil"/>
+<param name="mdViaVia" value="4mil"/>
+<param name="mdSmdPad" value="0mil"/>
+<param name="mdSmdVia" value="0mil"/>
+<param name="mdSmdSmd" value="0mil"/>
+<param name="mdViaViaSameLayer" value="6mil"/>
+<param name="mnLayersViaInSmd" value="2"/>
+<param name="mdCopperDimension" value="0mil"/>
+<param name="mdDrill" value="6mil"/>
+<param name="mdSmdStop" value="0mil"/>
+<param name="msWidth" value="4mil"/>
+<param name="msDrill" value="0.3mm"/>
+<param name="msMicroVia" value="9.99mm"/>
+<param name="msBlindViaRatio" value="0.5"/>
+<param name="rvPadTop" value="0.25"/>
+<param name="rvPadInner" value="0.25"/>
+<param name="rvPadBottom" value="0.25"/>
+<param name="rvViaOuter" value="0.25"/>
+<param name="rvViaInner" value="0.25"/>
+<param name="rvMicroViaOuter" value="0.25"/>
+<param name="rvMicroViaInner" value="0.25"/>
+<param name="rlMinPadTop" value="4mil"/>
+<param name="rlMaxPadTop" value="20mil"/>
+<param name="rlMinPadInner" value="4mil"/>
+<param name="rlMaxPadInner" value="20mil"/>
+<param name="rlMinPadBottom" value="4mil"/>
+<param name="rlMaxPadBottom" value="20mil"/>
+<param name="rlMinViaOuter" value="0.15mm"/>
+<param name="rlMaxViaOuter" value="20mil"/>
+<param name="rlMinViaInner" value="0.15mm"/>
+<param name="rlMaxViaInner" value="20mil"/>
+<param name="rlMinMicroViaOuter" value="4mil"/>
+<param name="rlMaxMicroViaOuter" value="20mil"/>
+<param name="rlMinMicroViaInner" value="4mil"/>
+<param name="rlMaxMicroViaInner" value="20mil"/>
+<param name="psTop" value="-1"/>
+<param name="psBottom" value="-1"/>
+<param name="psFirst" value="-1"/>
+<param name="psElongationLong" value="100"/>
+<param name="psElongationOffset" value="100"/>
+<param name="mvStopFrame" value="1"/>
+<param name="mvCreamFrame" value="0"/>
+<param name="mlMinStopFrame" value="4mil"/>
+<param name="mlMaxStopFrame" value="4mil"/>
+<param name="mlMinCreamFrame" value="0mil"/>
+<param name="mlMaxCreamFrame" value="0mil"/>
+<param name="mlViaStopLimit" value="0mil"/>
+<param name="srRoundness" value="0"/>
+<param name="srMinRoundness" value="0mil"/>
+<param name="srMaxRoundness" value="0mil"/>
+<param name="slThermalIsolate" value="10mil"/>
+<param name="slThermalsForVias" value="0"/>
+<param name="dpMaxLengthDifference" value="10mm"/>
+<param name="dpGapFactor" value="2.5"/>
+<param name="checkAngle" value="0"/>
+<param name="checkFont" value="1"/>
+<param name="checkRestrict" value="1"/>
+<param name="checkStop" value="0"/>
+<param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
+<param name="useDiameter" value="13"/>
+<param name="maxErrors" value="50"/>
+</designrules>
+<autorouter>
+<pass name="Default">
+<param name="RoutingGrid" value="50mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="0"/>
+<param name="TopRouterVariant" value="1"/>
+<param name="tpViaShape" value="round"/>
+<param name="PrefDir.1" value="a"/>
+<param name="PrefDir.2" value="0"/>
+<param name="PrefDir.3" value="0"/>
+<param name="PrefDir.4" value="0"/>
+<param name="PrefDir.5" value="0"/>
+<param name="PrefDir.6" value="0"/>
+<param name="PrefDir.7" value="0"/>
+<param name="PrefDir.8" value="0"/>
+<param name="PrefDir.9" value="0"/>
+<param name="PrefDir.10" value="0"/>
+<param name="PrefDir.11" value="0"/>
+<param name="PrefDir.12" value="0"/>
+<param name="PrefDir.13" value="0"/>
+<param name="PrefDir.14" value="0"/>
+<param name="PrefDir.15" value="0"/>
+<param name="PrefDir.16" value="a"/>
+<param name="cfVia" value="8"/>
+<param name="cfNonPref" value="5"/>
+<param name="cfChangeDir" value="2"/>
+<param name="cfOrthStep" value="2"/>
+<param name="cfDiagStep" value="3"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="1"/>
+<param name="cfMalusStep" value="1"/>
+<param name="cfPadImpact" value="4"/>
+<param name="cfSmdImpact" value="4"/>
+<param name="cfBusImpact" value="0"/>
+<param name="cfHugging" value="3"/>
+<param name="cfAvoid" value="4"/>
+<param name="cfPolygon" value="10"/>
+<param name="cfBase.1" value="0"/>
+<param name="cfBase.2" value="1"/>
+<param name="cfBase.3" value="1"/>
+<param name="cfBase.4" value="1"/>
+<param name="cfBase.5" value="1"/>
+<param name="cfBase.6" value="1"/>
+<param name="cfBase.7" value="1"/>
+<param name="cfBase.8" value="1"/>
+<param name="cfBase.9" value="1"/>
+<param name="cfBase.10" value="1"/>
+<param name="cfBase.11" value="1"/>
+<param name="cfBase.12" value="1"/>
+<param name="cfBase.13" value="1"/>
+<param name="cfBase.14" value="1"/>
+<param name="cfBase.15" value="1"/>
+<param name="cfBase.16" value="0"/>
+<param name="mnVias" value="20"/>
+<param name="mnSegments" value="9999"/>
+<param name="mnExtdSteps" value="9999"/>
+<param name="mnRipupLevel" value="10"/>
+<param name="mnRipupSteps" value="100"/>
+<param name="mnRipupTotal" value="100"/>
+</pass>
+<pass name="Follow-me" refer="Default" active="yes">
+</pass>
+<pass name="Busses" refer="Default" active="yes">
+<param name="cfNonPref" value="4"/>
+<param name="cfBusImpact" value="4"/>
+<param name="cfHugging" value="0"/>
+<param name="mnVias" value="0"/>
+</pass>
+<pass name="Route" refer="Default" active="yes">
+</pass>
+<pass name="Optimize1" refer="Default" active="yes">
+<param name="cfVia" value="99"/>
+<param name="cfExtdStep" value="10"/>
+<param name="cfHugging" value="1"/>
+<param name="mnExtdSteps" value="1"/>
+<param name="mnRipupLevel" value="0"/>
+</pass>
+<pass name="Optimize2" refer="Optimize1" active="yes">
+<param name="cfNonPref" value="0"/>
+<param name="cfChangeDir" value="6"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="2"/>
+<param name="cfMalusStep" value="2"/>
+<param name="cfPadImpact" value="2"/>
+<param name="cfSmdImpact" value="2"/>
+<param name="cfHugging" value="0"/>
+</pass>
+<pass name="Optimize3" refer="Optimize2" active="yes">
+<param name="cfChangeDir" value="8"/>
+<param name="cfPadImpact" value="0"/>
+<param name="cfSmdImpact" value="0"/>
+</pass>
+<pass name="Optimize4" refer="Optimize3" active="yes">
+<param name="cfChangeDir" value="25"/>
+</pass>
+</autorouter>
+<elements>
+<element name="USBC1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="WüRTH_632712000112" package3d_urn="urn:adsk.eagle:package:9339182/7" value="DX07P024AJ5R1500WURTH" x="17.69" y="49.9" smashed="yes" rot="R270"/>
+<element name="R2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="R0402" package3d_urn="urn:adsk.eagle:package:4245807/8" value="5k" x="20.99" y="44.06" smashed="yes" rot="R270">
+<attribute name="NAME" x="20.035" y="43.455" size="0.6096" layer="25" ratio="15" rot="R270"/>
+<attribute name="VALUE" x="19.785" y="44.595" size="0.6096" layer="27" rot="R270"/>
+</element>
+<element name="C1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u" x="26.64" y="53.03" smashed="yes">
+<attribute name="NAME" x="26.545" y="53.715" size="0.6096" layer="25" ratio="15"/>
+<attribute name="VALUE" x="27.905" y="52.825" size="0.6096" layer="27"/>
+</element>
+<element name="C2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="26.63" y="52.19" smashed="yes">
+<attribute name="NAME" x="26.665" y="51.055" size="0.6096" layer="25" ratio="15"/>
+<attribute name="VALUE" x="28.095" y="51.985" size="0.6096" layer="27"/>
+</element>
+<element name="C4" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u" x="21.5" y="49.225" smashed="yes" rot="R180">
+<attribute name="NAME" x="20.445" y="49.42" size="0.6096" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="C5" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="21.48" y="48.3" smashed="yes" rot="R180">
+<attribute name="NAME" x="20.635" y="47.805" size="0.6096" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="GND2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="B1,27" package3d_urn="urn:adsk.eagle:package:4245792/4" value="TEST_POINT" x="34.2" y="43.79" smashed="yes" rot="MR0">
+<attribute name="NAME" x="36.635" y="44.206" size="0.6096" layer="26" ratio="10" rot="MR0"/>
+<attribute name="VALUE" x="34.835" y="43.028" size="0.0254" layer="28" rot="MR0"/>
+</element>
+<element name="+5V2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="B1,27" package3d_urn="urn:adsk.eagle:package:4245792/4" value="TEST_POINT" x="17.82" y="53.7" smashed="yes" rot="MR0">
+<attribute name="NAME" x="18.925" y="52.316" size="0.6096" layer="26" ratio="10" rot="MR0"/>
+<attribute name="VALUE" x="18.455" y="52.938" size="0.0254" layer="28" rot="MR0"/>
+</element>
+<element name="3V2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="B1,27" package3d_urn="urn:adsk.eagle:package:4245792/4" value="TEST_POINT" x="29.46" y="42.89" smashed="yes" rot="MR0">
+<attribute name="NAME" x="31.655" y="41.916" size="0.6096" layer="26" ratio="10" rot="MR0"/>
+<attribute name="VALUE" x="29.595" y="42.628" size="0.0254" layer="28" rot="MR0"/>
+</element>
+<element name="SWDIO2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="B1,27" package3d_urn="urn:adsk.eagle:package:4245792/4" value="TEST_POINT" x="18.16" y="40.38" smashed="yes" rot="MR0">
+<attribute name="NAME" x="20.055" y="41.076" size="0.6096" layer="26" ratio="10" rot="MR0"/>
+<attribute name="VALUE" x="18.795" y="39.618" size="0.0254" layer="28" rot="MR0"/>
+</element>
+<element name="SWCLK2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="B1,27" package3d_urn="urn:adsk.eagle:package:4245792/4" value="TEST_POINT" x="23.65" y="42.34" smashed="yes" rot="MR0">
+<attribute name="NAME" x="25.375" y="40.956" size="0.6096" layer="26" ratio="15" rot="MR0"/>
+<attribute name="VALUE" x="24.285" y="41.578" size="0.0254" layer="28" rot="MR0"/>
+</element>
+<element name="R1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="R0402" package3d_urn="urn:adsk.eagle:package:4245807/8" value="175" x="27.84" y="41.85" smashed="yes" rot="R90">
+<attribute name="NAME" x="28.945" y="41.305" size="0.6096" layer="25" ratio="15" rot="R90"/>
+</element>
+<element name="C6" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u" x="30.62" y="44.49" smashed="yes" rot="R180">
+<attribute name="NAME" x="33.035" y="45.105" size="0.6096" layer="25" ratio="15" rot="R180"/>
+<attribute name="VALUE" x="33.905" y="45.845" size="0.6096" layer="27" rot="R180"/>
+</element>
+<element name="C13" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="30.62" y="43.64" smashed="yes" rot="R180">
+<attribute name="NAME" x="33.305" y="43.665" size="0.6096" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="ST1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="QFN32" package3d_urn="urn:adsk.eagle:package:4245373/9" value="STM32L432KCU6" x="25.45" y="47.29" smashed="yes" rot="R180">
+<attribute name="NAME" x="26.34" y="50.72" size="0.6096" layer="25" ratio="15" rot="R180"/>
+<attribute name="VALUE" x="29.5" y="51.64" size="1.27" layer="27" rot="R180" display="off"/>
+</element>
+<element name="L3" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="REG_NCP114AMX330TCG" package3d_urn="urn:adsk.eagle:package:5621121/4" value="NCP114AMX330TCG" x="24.57" y="52.13" smashed="yes">
+<attribute name="AVAILABILITY" value="Unavailable" x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="DESCRIPTION" value=" CMOS Low Dropout Regulator _LDO_, 300 mA 3.3V, Active Discharge " x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="MF" value="ON Semiconductor" x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="MP" value="NCP114AMX330TCG" x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="NAME" x="23.427009375" y="52.42771875" size="0.6" layer="25" ratio="15" rot="R90"/>
+<attribute name="PACKAGE" value="UDFN-4 ON Semiconductor" x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="PRICE" value="None" x="24.57" y="52.13" size="1.778" layer="27" font="vector" display="off"/>
+<attribute name="VALUE" x="26.5149" y="50.137078125" size="0.306003125" layer="27" rot="R90" display="off"/>
+</element>
+<element name="Z1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="BZA900A" package3d_urn="urn:adsk.eagle:package:5621120/4" value="BZA900A-ESD-ZENERS" x="21.1" y="45.74" smashed="yes">
+<attribute name="NAME" x="21.1" y="46.28" size="0.7" layer="25" ratio="14"/>
+</element>
+<element name="N1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="MLPD3X3" package3d_urn="urn:adsk.eagle:package:5825738/8" value="AMS3956" x="43.986" y="49.53" smashed="yes" rot="R180">
+<attribute name="NAME" x="41.97" y="52.696" size="0.8" layer="25" ratio="15"/>
+<attribute name="VALUE" x="44.696" y="49.86" size="0.6096" layer="27" ratio="15" rot="R180"/>
+</element>
+<element name="C15" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="12p" x="44.82" y="51.07" smashed="yes" rot="R90">
+<attribute name="NAME" x="44.965" y="46.935" size="0.8" layer="25" ratio="15" rot="R90"/>
+</element>
+<element name="C14" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="33p" x="45.59" y="51.07" smashed="yes" rot="R90">
+<attribute name="NAME" x="45.935" y="46.995" size="0.8" layer="25" ratio="15" rot="R90"/>
+</element>
+<element name="C3" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="30.74" y="42.77" smashed="yes" rot="R180">
+<attribute name="NAME" x="32.915" y="42.865" size="0.6096" layer="25" ratio="15" rot="R180"/>
+<attribute name="VALUE" x="31.375" y="44.675" size="1.27" layer="27" rot="R180" display="off"/>
+</element>
+<element name="C7" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="30.72" y="41.9" smashed="yes" rot="R180">
+<attribute name="NAME" x="33.145" y="41.995" size="0.7" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="C8" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="21.53" y="50.16" smashed="yes" rot="R180">
+<attribute name="NAME" x="20.575" y="50.225" size="0.7" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="C9" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="C0402" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u" x="21.54" y="50.99" smashed="yes" rot="R180">
+<attribute name="NAME" x="20.615" y="51.765" size="0.7" layer="25" ratio="15" rot="R180"/>
+</element>
+<element name="L1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" package="CL-505S-X-SD-T" package3d_urn="urn:adsk.eagle:package:4878740/9" value="RGB_LED_1X1CL-505S-X-SD-T" x="35.36" y="47.45" smashed="yes" rot="R180">
+<attribute name="NAME" x="35.76" y="46.05" size="0.4" layer="21" rot="R180"/>
+</element>
+<element name="R25" library="ultra_librarian" package="RC0402N-L" value="1k" x="23.39" y="41.57" smashed="yes" rot="R180">
+<attribute name="MANUFACTURER_PART_NUMBER" value="RC0402FR071KL" x="23.39" y="41.57" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="22.6066" y="40.315" size="0.6096" layer="25" ratio="6" rot="SR0"/>
+<attribute name="VENDOR" value="Yageo" x="23.39" y="41.57" size="1.778" layer="27" rot="R180" display="off"/>
+</element>
+<element name="R26" library="ultra_librarian" package="RC0402N-L" value="1k" x="25.5" y="41.52" smashed="yes" rot="R180">
+<attribute name="MANUFACTURER_PART_NUMBER" value="RC0402FR071KL" x="25.5" y="41.52" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="25.2366" y="40.435" size="0.6096" layer="25" ratio="6" rot="SR0"/>
+<attribute name="VENDOR" value="Yageo" x="25.5" y="41.52" size="1.778" layer="27" rot="R180" display="off"/>
+</element>
+<element name="C23" library="GRM2195C1H103FA01D" package="CAPC2012X95N" value="10nF" x="24.85" y="43.02" smashed="yes">
+<attribute name="DESCRIPTION" value=" Multilayer Ceramic Capacitor, GRM Series, 0.01 F, 1%, C0G / NP0, 50 V, 0805 [2012 Metric] " x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="DIGI-KEY_PART_NUMBER" value="490-8295-1-ND" x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="DIGI-KEY_PURCHASE_URL" value="https://www.digikey.com/product-detail/en/murata-electronics/GRM2195C1H103FA01D/490-8295-1-ND/4380589?utm_source=snapeda&amp;utm_medium=aggregator&amp;utm_campaign=symbol" x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="MF" value="Murata" x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="MP" value="GRM2195C1H103FA01D" x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="22.6" y="42.37" size="0.5" layer="25" rot="R90"/>
+<attribute name="PACKAGE" value="2012 Murata" x="24.85" y="43.02" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="23.19" y="42" size="0.5" layer="27" align="top-left"/>
+</element>
+</elements>
+<signals>
+<signal name="+5V">
+<contactref element="USBC1" pad="A4"/>
+<contactref element="USBC1" pad="B4"/>
+<contactref element="USBC1" pad="B9"/>
+<contactref element="USBC1" pad="A9"/>
+<contactref element="C2" pad="1"/>
+<contactref element="C1" pad="1"/>
+<contactref element="+5V2" pad="TP"/>
+<contactref element="L3" pad="4"/>
+<contactref element="L3" pad="3"/>
+<wire x1="25.98" y1="53.020003125" x2="26.015" y2="53.03" width="0.2032" layer="1"/>
+<contactref element="Z1" pad="P$1"/>
+<wire x1="19.81" y1="48.24450625" x2="19.81" y2="46.522" width="0.3048" layer="16"/>
+<wire x1="19.81" y1="46.522" x2="19.794003125" y2="46.538003125" width="0.3048" layer="16"/>
+<wire x1="24.4875" y1="52.8625" x2="24.425" y2="52.8" width="0.254" layer="1"/>
+<wire x1="24.5375" y1="52.8125" x2="24.4875" y2="52.8625" width="0.254" layer="1"/>
+<wire x1="24.4875" y1="52.8625" x2="24.445" y2="52.905" width="0.254" layer="1"/>
+<wire x1="24.445" y1="52.905" x2="23.3" y2="54.05" width="0.254" layer="1"/>
+<wire x1="23.3" y1="54.05" x2="20.17" y2="54.05" width="0.254" layer="1"/>
+<wire x1="19.98" y1="54.05" x2="19.54" y2="54.05" width="0.254" layer="1"/>
+<wire x1="19.54" y1="54.05" x2="19.45" y2="54.05" width="0.254" layer="1"/>
+<wire x1="19.45" y1="54.05" x2="19.41" y2="54.05" width="0.254" layer="1"/>
+<wire x1="17.82" y1="53.7" x2="18.37" y2="53.7" width="0.1524" layer="16"/>
+<wire x1="24.245" y1="52.63" x2="24.445" y2="52.83" width="0.25" layer="1"/>
+<wire x1="24.445" y1="52.83" x2="24.445" y2="52.905" width="0.25" layer="1"/>
+<wire x1="24.5375" y1="52.8125" x2="24.73808125" y2="52.8125" width="0.25" layer="1"/>
+<wire x1="24.895" y1="52.63" x2="24.895" y2="52.65558125" width="0.25" layer="1"/>
+<wire x1="24.895" y1="52.65558125" x2="24.73808125" y2="52.8125" width="0.25" layer="1"/>
+<wire x1="24.895" y1="52.63" x2="25.285003125" y2="53.020003125" width="0.25" layer="1"/>
+<wire x1="25.285003125" y1="53.020003125" x2="25.98" y2="53.020003125" width="0.25" layer="1"/>
+<wire x1="26.005" y1="52.19" x2="26.03" y2="53.02" width="0.25" layer="1"/>
+<wire x1="26.03" y1="53.02" x2="26.015" y2="53.03" width="0.25" layer="1"/>
+<wire x1="18.48" y1="45.735" x2="18.483903125" y2="45.738903125" width="0.254" layer="1"/>
+<wire x1="18.7110125" y1="48.245125" x2="18.565125" y2="48.245125" width="0.25" layer="1"/>
+<wire x1="18.552209375" y1="48.232209375" x2="18.565125" y2="48.245125" width="0.25" layer="1"/>
+<via x="19.701221875" y="45.741221875" extent="1-16" drill="0.3"/>
+<wire x1="19.401221875" y1="45.741221875" x2="19.701221875" y2="45.741221875" width="0.2" layer="1"/>
+<wire x1="19.401221875" y1="45.741221875" x2="19.39341875" y2="45.749025" width="0.2" layer="1"/>
+<wire x1="19.27" y1="45.7399875" x2="19.3800125" y2="45.7399875" width="0.2" layer="16"/>
+<via x="19.7" y="48.24" extent="1-16" drill="0.3"/>
+<wire x1="19.7" y1="48.24" x2="19.94" y2="48.48" width="0.25" layer="1"/>
+<wire x1="20.17" y1="54.05" x2="19.54" y2="54.05" width="0.25" layer="1"/>
+<via x="19.54" y="54.05" extent="1-16" drill="0.3"/>
+<wire x1="17.82" y1="53.7" x2="18.17" y2="54.05" width="0.1524" layer="16"/>
+<wire x1="18.17" y1="54.05" x2="19.54" y2="54.05" width="0.1524" layer="16"/>
+<wire x1="19.7" y1="48.24" x2="20.22" y2="48.76" width="0.25" layer="1"/>
+<wire x1="20.22" y1="48.76" x2="20.22" y2="52.12" width="0.25" layer="1"/>
+<wire x1="20.22" y1="52.12" x2="19.24" y2="53.1" width="0.25" layer="1"/>
+<wire x1="19.24" y1="53.84" x2="19.45" y2="54.05" width="0.25" layer="1"/>
+<wire x1="19.24" y1="53.1" x2="19.24" y2="53.84" width="0.25" layer="1"/>
+<wire x1="19.701221875" y1="45.741221875" x2="19.81" y2="46.522" width="0.254" layer="16"/>
+<wire x1="21.4678" y1="45.04365" x2="21.4678" y2="44.17635" width="0.1524" layer="1"/>
+<wire x1="21.4678" y1="44.17635" x2="21.36365" y2="44.0722" width="0.1524" layer="1"/>
+<wire x1="21.36365" y1="44.0722" x2="20.61635" y2="44.0722" width="0.1524" layer="1"/>
+<wire x1="20.61635" y1="44.0722" x2="20.4922" y2="44.19635" width="0.1524" layer="1"/>
+<wire x1="20.4922" y1="44.19635" x2="20.4922" y2="44.6185875" width="0.1524" layer="1"/>
+<wire x1="20.4922" y1="44.6185875" x2="20.18583125" y2="44.92495625" width="0.1524" layer="1"/>
+<wire x1="20.18583125" y1="44.92495625" x2="20.18583125" y2="45.2566125" width="0.1524" layer="1"/>
+<wire x1="21.05" y1="45.74" x2="21.05" y2="45.46145" width="0.1524" layer="1"/>
+<wire x1="21.05" y1="45.46145" x2="21.4678" y2="45.04365" width="0.1524" layer="1"/>
+<wire x1="20.18583125" y1="45.2566125" x2="19.701221875" y2="45.741221875" width="0.1524" layer="1"/>
+<wire x1="19.7" y1="48.24" x2="18.7161375" y2="48.24" width="0.1524" layer="1"/>
+<wire x1="18.7161375" y1="48.24" x2="18.7110125" y2="48.245125" width="0.1524" layer="1"/>
+<wire x1="18.71088125" y1="48.24450625" x2="19.81" y2="48.24450625" width="0.1524" layer="16"/>
+<wire x1="19.7" y1="48.24" x2="18.7153875" y2="48.24" width="0.1524" layer="16"/>
+<wire x1="18.7153875" y1="48.24" x2="18.71088125" y2="48.24450625" width="0.1524" layer="16"/>
+<wire x1="18.70905625" y1="45.7399875" x2="18.4849875" y2="45.7399875" width="0.1524" layer="16"/>
+<wire x1="18.4849875" y1="45.7399875" x2="18.48" y2="45.735" width="0.1524" layer="16"/>
+<wire x1="18.4849875" y1="45.7399875" x2="18.486221875" y2="45.741221875" width="0.1524" layer="16"/>
+<wire x1="18.486221875" y1="45.741221875" x2="19.43" y2="45.741221875" width="0.1524" layer="16"/>
+<wire x1="19.02" y1="45.738903125" x2="19.398903125" y2="45.738903125" width="0.1524" layer="1"/>
+<wire x1="19.398903125" y1="45.738903125" x2="19.401221875" y2="45.741221875" width="0.1524" layer="1"/>
+<wire x1="19.02231875" y1="45.741221875" x2="19.02" y2="45.738903125" width="0.1524" layer="1"/>
+<wire x1="18.710959375" y1="45.738903125" x2="18.70705625" y2="45.735" width="0.1524" layer="1"/>
+<wire x1="18.70705625" y1="45.735" x2="18.48" y2="45.735" width="0.1524" layer="1"/>
+<wire x1="19.698903125" y1="45.738903125" x2="19.398903125" y2="45.738903125" width="0.1524" layer="1"/>
+<wire x1="18.710959375" y1="45.738903125" x2="19.02" y2="45.738903125" width="0.1524" layer="1"/>
+<wire x1="19.698903125" y1="45.738903125" x2="19.701221875" y2="45.741221875" width="0.1524" layer="1"/>
+<wire x1="19.701221875" y1="45.741221875" x2="19.02231875" y2="45.741221875" width="0.1524" layer="1"/>
+<wire x1="18.70905625" y1="45.7399875" x2="19.27" y2="45.7399875" width="0.1524" layer="16"/>
+<wire x1="19.27" y1="45.7399875" x2="19.428765625" y2="45.7399875" width="0.1524" layer="16"/>
+<wire x1="19.428765625" y1="45.7399875" x2="19.43" y2="45.741221875" width="0.1524" layer="16"/>
+<wire x1="19.701221875" y1="45.741221875" x2="19.43" y2="45.741221875" width="0.1524" layer="16"/>
+<wire x1="19.701221875" y1="45.741221875" x2="19.271234375" y2="45.741221875" width="0.1524" layer="16"/>
+<wire x1="19.271234375" y1="45.741221875" x2="19.27" y2="45.7399875" width="0.1524" layer="16"/>
+</signal>
+<signal name="PE">
+<contactref element="R2" pad="2"/>
+<contactref element="USBC1" pad="A1"/>
+<contactref element="USBC1" pad="B12"/>
+<contactref element="USBC1" pad="P_GND4"/>
+<contactref element="USBC1" pad="B1"/>
+<contactref element="USBC1" pad="P_GND3"/>
+<contactref element="USBC1" pad="A12"/>
+<wire x1="18.70615" y1="49.73" x2="18.7085625" y2="49.745346875" width="0.254" layer="16"/>
+<contactref element="C1" pad="2"/>
+<contactref element="C2" pad="2"/>
+<contactref element="C5" pad="2"/>
+<contactref element="C4" pad="2"/>
+<contactref element="GND2" pad="TP"/>
+<contactref element="C13" pad="2"/>
+<contactref element="C6" pad="2"/>
+<contactref element="ST1" pad="16"/>
+<contactref element="ST1" pad="32"/>
+<contactref element="ST1" pad="EXP"/>
+<contactref element="L3" pad="2"/>
+<contactref element="Z1" pad="P$2"/>
+<via x="25.45" y="47.29" extent="1-16" drill="0.35"/>
+<wire x1="25.55" y1="47.29" x2="25.45" y2="47.29" width="0.254" layer="16"/>
+<wire x1="24.85" y1="47.89" x2="25.45" y2="47.29" width="0.254" layer="16"/>
+<wire x1="24.8" y1="47.89" x2="24.85" y2="47.89" width="0.254" layer="16"/>
+<via x="24.8" y="47.89" extent="1-16" drill="0.35"/>
+<wire x1="24.85" y1="47.89" x2="24.8" y2="47.89" width="0.254" layer="1"/>
+<wire x1="24.95" y1="47.79" x2="26.15" y2="47.79" width="0.254" layer="1"/>
+<via x="26.15" y="47.79" extent="1-16" drill="0.35"/>
+<wire x1="24.85" y1="47.89" x2="25.45" y2="47.29" width="0.254" layer="1"/>
+<via x="26.2" y="46.54" extent="1-16" drill="0.35"/>
+<wire x1="25.45" y1="47.29" x2="25.75" y2="46.99" width="0.254" layer="1"/>
+<wire x1="25.75" y1="46.99" x2="26.2" y2="46.54" width="0.254" layer="1"/>
+<wire x1="24.95" y1="47.79" x2="24.95" y2="46.54" width="0.254" layer="1"/>
+<via x="24.95" y="46.54" extent="1-16" drill="0.35"/>
+<wire x1="27.2" y1="45.34" x2="25.75" y2="46.79" width="0.1524" layer="1"/>
+<wire x1="27.2" y1="44.94" x2="27.2" y2="45.34" width="0.1524" layer="1"/>
+<wire x1="25.75" y1="46.79" x2="25.75" y2="46.99" width="0.1524" layer="1"/>
+<wire x1="23.7" y1="49.64" x2="23.7214" y2="49.5686" width="0.1524" layer="1"/>
+<wire x1="23.7214" y1="49.5686" x2="23.7214" y2="49.12166875" width="0.1524" layer="1"/>
+<wire x1="23.7214" y1="49.12166875" x2="23.78166875" y2="49.0614" width="0.1524" layer="1"/>
+<wire x1="23.78166875" y1="49.0614" x2="23.8286" y2="49.0614" width="0.1524" layer="1"/>
+<wire x1="23.8286" y1="49.0614" x2="24.049275" y2="48.840725" width="0.1524" layer="1"/>
+<wire x1="24.049275" y1="48.840725" x2="25.45" y2="47.44" width="0.1524" layer="1"/>
+<wire x1="25.45" y1="47.44" x2="25.45" y2="47.29" width="0.1524" layer="1"/>
+<contactref element="N1" pad="P5"/>
+<contactref element="N1" pad="P$11"/>
+<via x="24.47" y="50.85" extent="1-16" drill="0.3"/>
+<via x="28.3464" y="52.13" extent="1-16" drill="0.35"/>
+<wire x1="42.948225" y1="52.07" x2="43.986" y2="52.07" width="0.1524" layer="1"/>
+<wire x1="40.188" y1="49.08" x2="40.193065625" y2="49.08250625" width="0.1524" layer="1"/>
+<via x="40.188" y="49.08" extent="1-16" drill="0.35"/>
+<wire x1="20.7675" y1="49.3575" x2="20.875" y2="49.225" width="0.3048" layer="1"/>
+<wire x1="24.27" y1="51.05" x2="24.47" y2="50.85" width="0.3048" layer="16"/>
+<wire x1="28.1964" y1="51.98" x2="25.6" y2="51.98" width="0.3048" layer="16"/>
+<wire x1="24.47" y1="50.85" x2="25.6" y2="51.98" width="0.3048" layer="16"/>
+<wire x1="28.1964" y1="51.98" x2="28.3464" y2="52.13" width="0.3048" layer="16"/>
+<wire x1="30.8064" y1="49.6" x2="28.3464" y2="52.06" width="0.3048" layer="16"/>
+<wire x1="28.3464" y1="52.13" x2="28.3464" y2="52.06" width="0.3048" layer="16"/>
+<wire x1="34.36" y1="49.6" x2="30.8064" y2="49.6" width="0.3048" layer="16"/>
+<wire x1="34.2" y1="43.19" x2="34.2" y2="43.79" width="0.3048" layer="16"/>
+<wire x1="25.45" y1="47.29" x2="26.2" y2="46.54" width="0.3048" layer="16"/>
+<wire x1="24.95" y1="46.54" x2="25.45" y2="47.04" width="0.3048" layer="16"/>
+<wire x1="25.45" y1="47.04" x2="25.45" y2="47.29" width="0.3048" layer="16"/>
+<wire x1="26.15" y1="47.79" x2="25.65" y2="47.29" width="0.3048" layer="16"/>
+<wire x1="25.65" y1="47.29" x2="25.55" y2="47.29" width="0.3048" layer="16"/>
+<wire x1="24.8" y1="47.89" x2="28.3464" y2="51.4364" width="0.3048" layer="16"/>
+<wire x1="28.3464" y1="51.4364" x2="28.3464" y2="52.13" width="0.3048" layer="16"/>
+<wire x1="25.5" y1="49.82" x2="25.5" y2="48.59" width="0.3048" layer="16"/>
+<wire x1="24.8" y1="47.89" x2="25.5" y2="48.59" width="0.3048" layer="16"/>
+<wire x1="25.5" y1="49.82" x2="24.47" y2="50.85" width="0.3048" layer="16"/>
+<wire x1="40.188" y1="49.08" x2="38.898" y2="47.79" width="0.3048" layer="16"/>
+<wire x1="38.898" y1="47.79" x2="36.17" y2="47.79" width="0.3048" layer="16"/>
+<wire x1="34.36" y1="49.6" x2="36.17" y2="47.79" width="0.3048" layer="16"/>
+<wire x1="40.848" y1="49.52" x2="40.408" y2="49.08" width="0.3048" layer="1"/>
+<wire x1="40.188" y1="49.08" x2="40.408" y2="49.08" width="0.3048" layer="1"/>
+<wire x1="40.848" y1="49.52" x2="41.63" y2="49.52" width="0.3048" layer="1"/>
+<wire x1="41.63" y1="49.52" x2="42.758" y2="50.648" width="0.3048" layer="1"/>
+<wire x1="42.758" y1="50.648" x2="42.353" y2="51.053" width="0.3048" layer="1"/>
+<wire x1="42.386" y1="51.17" x2="42.563778125" y2="51.17" width="0.3048" layer="1"/>
+<wire x1="24.47" y1="50.85" x2="24.3275" y2="50.9925" width="0.254" layer="1"/>
+<wire x1="24.895" y1="51.63" x2="24.965" y2="51.63" width="0.254" layer="1"/>
+<via x="19.96" y="44.29" extent="1-16" drill="0.3"/>
+<wire x1="20.875" y1="49.225" x2="20.88" y2="49.205" width="0.254" layer="1"/>
+<wire x1="20.88" y1="49.205" x2="20.855" y2="48.3" width="0.254" layer="1"/>
+<via x="23.31" y="51.75" extent="1-16" drill="0.3"/>
+<wire x1="20.875" y1="49.225" x2="20.74" y2="49.065" width="0.254" layer="1"/>
+<wire x1="20.74" y1="49.265" x2="20.87" y2="49.395" width="0.254" layer="1"/>
+<wire x1="24.47" y1="50.85" x2="23.57" y2="51.75" width="0.254" layer="16"/>
+<wire x1="23.57" y1="51.75" x2="23.31" y2="51.75" width="0.254" layer="16"/>
+<contactref element="C3" pad="2"/>
+<contactref element="C7" pad="2"/>
+<contactref element="C8" pad="2"/>
+<contactref element="C9" pad="2"/>
+<wire x1="30.115" y1="42.77" x2="30.14" y2="41.92" width="0.3048" layer="1"/>
+<wire x1="30.095" y1="41.9" x2="30.14" y2="41.92" width="0.3048" layer="1"/>
+<wire x1="29.995" y1="43.64" x2="30.14" y2="43.52" width="0.3048" layer="1"/>
+<wire x1="30.14" y1="43.52" x2="30.115" y2="42.77" width="0.3048" layer="1"/>
+<wire x1="20.915" y1="50.99" x2="20.94" y2="50.93" width="0.2" layer="1"/>
+<wire x1="20.94" y1="50.93" x2="20.94" y2="50.39" width="0.2" layer="1"/>
+<wire x1="20.94" y1="50.39" x2="20.94" y2="50.17" width="0.2" layer="1"/>
+<wire x1="20.905" y1="50.16" x2="20.94" y2="50.17" width="0.2" layer="1"/>
+<wire x1="20.905" y1="50.16" x2="20.74" y2="49.97" width="0.2" layer="1"/>
+<wire x1="20.74" y1="49.97" x2="20.74" y2="49.265" width="0.2" layer="1"/>
+<wire x1="20.74" y1="49.265" x2="20.74" y2="49.065" width="0.2" layer="1"/>
+<wire x1="27.64" y1="53.03" x2="27.265" y2="53.03" width="0.25" layer="1"/>
+<wire x1="28.3464" y1="52.13" x2="28.3464" y2="52.3236" width="0.25" layer="1"/>
+<wire x1="28.3464" y1="52.3236" x2="27.64" y2="53.03" width="0.25" layer="1"/>
+<wire x1="27.255" y1="52.19" x2="28.2864" y2="52.19" width="0.25" layer="1"/>
+<wire x1="28.2864" y1="52.19" x2="28.3464" y2="52.13" width="0.25" layer="1"/>
+<wire x1="23.31" y1="51.75" x2="21.42" y2="51.75" width="0.25" layer="1"/>
+<wire x1="21.42" y1="51.75" x2="21.335" y2="51.665" width="0.25" layer="1"/>
+<wire x1="21.335" y1="51.665" x2="20.94" y2="51.27" width="0.25" layer="1"/>
+<wire x1="20.94" y1="51.27" x2="20.915" y2="50.99" width="0.25" layer="1"/>
+<wire x1="24.895" y1="51.63" x2="24.895" y2="51.275" width="0.25" layer="1"/>
+<wire x1="24.895" y1="51.275" x2="24.47" y2="50.85" width="0.25" layer="1"/>
+<wire x1="42.353" y1="51.053" x2="42.428" y2="51.128" width="0.1524" layer="1"/>
+<wire x1="42.428" y1="51.128" x2="42.45" y2="51.15" width="0.1524" layer="1"/>
+<wire x1="42.615" y1="51.315" x2="42.948225" y2="51.648225" width="0.1524" layer="1"/>
+<wire x1="42.948225" y1="51.648225" x2="42.948225" y2="52.07" width="0.1524" layer="1"/>
+<via x="42.38" y="51.15" extent="1-16" drill="0.35"/>
+<wire x1="18.70879375" y1="49.745475" x2="18.835934375" y2="49.872615625" width="0.1524" layer="1"/>
+<wire x1="18.835934375" y1="49.872615625" x2="18.835934375" y2="50.423228125" width="0.1524" layer="1"/>
+<wire x1="18.8364125" y1="43.546171875" x2="18.8364125" y2="44.11998125" width="0.1524" layer="1"/>
+<wire x1="18.8364125" y1="44.11998125" x2="18.70689375" y2="44.2495" width="0.1524" layer="1"/>
+<wire x1="42.386" y1="51.17" x2="42.428" y2="51.128" width="0.1524" layer="1"/>
+<wire x1="42.386" y1="51.17" x2="42.531" y2="51.315" width="0.1524" layer="1"/>
+<wire x1="42.531" y1="51.315" x2="42.615" y2="51.315" width="0.1524" layer="1"/>
+<wire x1="42.615" y1="51.315" x2="42.45" y2="51.15" width="0.1524" layer="1"/>
+<wire x1="42.45" y1="51.15" x2="42.38" y2="51.15" width="0.1524" layer="1"/>
+<wire x1="19.96" y1="44.29" x2="18.94" y2="44.29" width="0.1524" layer="16"/>
+<wire x1="18.91" y1="44.26" x2="18.711225" y2="44.26" width="0.1524" layer="16"/>
+<wire x1="18.7047875" y1="44.2535625" x2="18.711225" y2="44.26" width="0.1524" layer="16"/>
+<contactref element="USBC1" pad="P_GND1"/>
+<contactref element="USBC1" pad="P_GND2"/>
+<wire x1="19.96" y1="44.29" x2="19.9195" y2="44.2495" width="0.254" layer="1"/>
+<wire x1="18.70689375" y1="44.2495" x2="19.9195" y2="44.2495" width="0.254" layer="1"/>
+<wire x1="19.96" y1="44.29" x2="20.79" y2="43.46" width="0.25" layer="1"/>
+<wire x1="20.79" y1="43.46" x2="20.99" y2="43.435" width="0.25" layer="1"/>
+<wire x1="20.99" y1="43.435" x2="21.31" y2="43.46" width="0.25" layer="1"/>
+<wire x1="21.62" y1="43.77" x2="21.31" y2="43.46" width="0.25" layer="1"/>
+<wire x1="21.62" y1="45.72" x2="21.6" y2="45.74" width="0.25" layer="1"/>
+<wire x1="20.906771875" y1="50.423228125" x2="20.94" y2="50.39" width="0.25" layer="1"/>
+<wire x1="19.96" y1="44.29" x2="20.23" y2="44.56" width="0.1524" layer="16"/>
+<wire x1="18.835934375" y1="50.423771875" x2="18.835934375" y2="49.87271875" width="0.1524" layer="16"/>
+<wire x1="18.835934375" y1="49.87271875" x2="18.7085625" y2="49.745346875" width="0.1524" layer="16"/>
+<wire x1="18.835934375" y1="50.423771875" x2="19.593771875" y2="50.423771875" width="0.1524" layer="16"/>
+<wire x1="19.593771875" y1="50.423771875" x2="19.79" y2="50.62" width="0.1524" layer="16"/>
+<wire x1="19.79" y1="50.68" x2="19.95" y2="50.84" width="0.1524" layer="16"/>
+<wire x1="19.95" y1="50.84" x2="19.8426" y2="50.9474" width="0.1524" layer="16"/>
+<wire x1="20.79" y1="51.08" x2="20.94" y2="50.93" width="0.1524" layer="1"/>
+<wire x1="19.79" y1="50.62" x2="19.79" y2="50.68" width="0.1524" layer="16"/>
+<wire x1="19.79" y1="50.68" x2="19.79" y2="53.15" width="0.1524" layer="16"/>
+<wire x1="19.79" y1="53.15" x2="19.93" y2="53.29" width="0.1524" layer="16"/>
+<via x="19.93" y="53.29" extent="1-16" drill="0.3"/>
+<wire x1="19.93" y1="53.29" x2="21.335" y2="51.885" width="0.1524" layer="1"/>
+<wire x1="21.335" y1="51.885" x2="21.335" y2="51.665" width="0.1524" layer="1"/>
+<wire x1="18.835934375" y1="50.423228125" x2="19.593228125" y2="50.423228125" width="0.1524" layer="1"/>
+<wire x1="19.593228125" y1="50.423228125" x2="19.593771875" y2="50.423771875" width="0.1524" layer="1"/>
+<via x="19.593771875" y="50.423771875" extent="1-16" drill="0.3"/>
+<wire x1="20.23" y1="49.78754375" x2="19.593771875" y2="50.423771875" width="0.1524" layer="16"/>
+<wire x1="20.23" y1="49.78754375" x2="20.23" y2="44.56" width="0.1524" layer="16"/>
+<wire x1="18.835934375" y1="43.560171875" x2="18.835934375" y2="44.185934375" width="0.1524" layer="16"/>
+<wire x1="18.835934375" y1="44.185934375" x2="18.91" y2="44.26" width="0.1524" layer="16"/>
+<wire x1="18.91" y1="44.26" x2="18.94" y2="44.29" width="0.1524" layer="16"/>
+<wire x1="21.6" y1="45.74" x2="21.6" y2="45.41" width="0.2032" layer="1"/>
+<wire x1="21.6" y1="45.41" x2="21.83" y2="45.18" width="0.2032" layer="1"/>
+<wire x1="21.83" y1="45.18" x2="21.83" y2="43.98" width="0.2032" layer="1"/>
+<wire x1="21.83" y1="43.98" x2="21.62" y2="43.77" width="0.2032" layer="1"/>
+<wire x1="27.2" y1="44.94" x2="27.65" y2="44.49" width="0.3048" layer="1"/>
+<wire x1="27.65" y1="44.49" x2="29.995" y2="44.49" width="0.3048" layer="1"/>
+<wire x1="29.995" y1="44.49" x2="29.995" y2="43.64" width="0.3048" layer="1"/>
+<wire x1="26.2" y1="46.54" x2="27.76" y2="44.98" width="0.3048" layer="16"/>
+<wire x1="27.76" y1="44.98" x2="27.9" y2="44.84" width="0.3048" layer="16"/>
+<wire x1="27.3944875" y1="44.84" x2="27.9" y2="44.84" width="0.3048" layer="16"/>
+<via x="26.93" y="42.42" extent="1-16" drill="0.35"/>
+<wire x1="26.93" y1="42.42" x2="26.89" y2="42.38" width="0.1524" layer="1"/>
+<wire x1="27.3944875" y1="44.84" x2="27.3944875" y2="42.8844875" width="0.3048" layer="16"/>
+<wire x1="27.3944875" y1="42.8844875" x2="26.93" y2="42.42" width="0.3048" layer="16"/>
+<wire x1="34.2" y1="44.14" x2="33.36" y2="44.98" width="0.3048" layer="16"/>
+<wire x1="34.2" y1="44.14" x2="34.2" y2="43.79" width="0.3048" layer="16"/>
+<wire x1="27.76" y1="44.98" x2="33.36" y2="44.98" width="0.3048" layer="16"/>
+<contactref element="ST1" pad="15"/>
+<contactref element="ST1" pad="18"/>
+<wire x1="23.1" y1="48.54" x2="23.74855" y2="48.54" width="0.1524" layer="1"/>
+<wire x1="23.74855" y1="48.54" x2="24.049275" y2="48.840725" width="0.1524" layer="1"/>
+<wire x1="24.2" y1="49.64" x2="24.2" y2="48.99145" width="0.1524" layer="1"/>
+<wire x1="24.2" y1="48.99145" x2="24.049275" y2="48.840725" width="0.1524" layer="1"/>
+<contactref element="C23" pad="2"/>
+<wire x1="26.93" y1="42.42" x2="26.338" y2="42.42" width="0.1524" layer="1"/>
+<wire x1="26.338" y1="42.42" x2="25.738" y2="43.02" width="0.1524" layer="1"/>
+</signal>
+<signal name="D+">
+<contactref element="USBC1" pad="A6"/>
+<contactref element="ST1" pad="22"/>
+<contactref element="Z1" pad="P$3"/>
+<wire x1="22.15" y1="45.79" x2="22.45" y2="46.09" width="0.1524" layer="1"/>
+<wire x1="22.45" y1="46.09" x2="22.45" y2="46.54" width="0.1524" layer="1"/>
+<wire x1="22.45" y1="46.54" x2="23.1" y2="46.54" width="0.1524" layer="1"/>
+<wire x1="22.15" y1="45.74" x2="22.1786" y2="45.73143125" width="0.1524" layer="1"/>
+<wire x1="22.23164375" y1="45.82164375" x2="21.3532875" y2="46.7" width="0.1524" layer="1"/>
+<wire x1="22.15" y1="45.74" x2="22.15" y2="45.79" width="0.1524" layer="1"/>
+<wire x1="22.15" y1="45.74" x2="22.23164375" y2="45.82164375" width="0.1524" layer="1"/>
+<wire x1="18.711084375" y1="46.74309375" x2="18.711084375" y2="46.83" width="0.1524" layer="1"/>
+<wire x1="21.3532875" y1="46.7" x2="20.60955625" y2="46.7" width="0.1524" layer="1"/>
+<wire x1="20.60955625" y1="46.7" x2="20.22795625" y2="47.0816" width="0.1524" layer="1"/>
+<wire x1="20.22795625" y1="47.0816" x2="19.74004375" y2="47.0816" width="0.1524" layer="1"/>
+<wire x1="19.74004375" y1="47.0816" x2="19.47844375" y2="46.82" width="0.1524" layer="1"/>
+<wire x1="19.47844375" y1="46.82" x2="18.787990625" y2="46.82" width="0.1524" layer="1"/>
+<wire x1="18.711084375" y1="46.74309375" x2="18.787990625" y2="46.82" width="0.1524" layer="1"/>
+</signal>
+<signal name="D-">
+<contactref element="USBC1" pad="A7"/>
+<contactref element="ST1" pad="21"/>
+<contactref element="Z1" pad="P$4"/>
+<wire x1="22.322728125" y1="47.217271875" x2="22.74375" y2="47.04" width="0.1524" layer="1"/>
+<wire x1="22.74375" y1="47.04" x2="23.1" y2="47.04" width="0.1524" layer="1"/>
+<wire x1="22.1" y1="47.44" x2="22.322728125" y2="47.217271875" width="0.1524" layer="1"/>
+<wire x1="22" y1="47.44" x2="22.1" y2="47.44" width="0.1524" layer="1"/>
+<wire x1="22" y1="47.44" x2="21.5173625" y2="46.9573625" width="0.1524" layer="1"/>
+<wire x1="18.716765625" y1="47.235125" x2="18.706765625" y2="47.245125" width="0.1524" layer="1"/>
+<wire x1="20.87" y1="46.9573625" x2="21.5173625" y2="46.9573625" width="0.1524" layer="1"/>
+<wire x1="18.801640625" y1="47.34" x2="18.706765625" y2="47.245125" width="0.1524" layer="1"/>
+<wire x1="20.87" y1="46.9573625" x2="20.55" y2="47.2773625" width="0.1524" layer="1"/>
+<wire x1="18.864278125" y1="47.2773625" x2="18.801640625" y2="47.34" width="0.1524" layer="1"/>
+<wire x1="20.55" y1="47.2773625" x2="20.39140625" y2="47.2773625" width="0.1524" layer="1"/>
+<wire x1="20.39140625" y1="47.2773625" x2="20.33316875" y2="47.3356" width="0.1524" layer="1"/>
+<wire x1="19.63483125" y1="47.3356" x2="19.57659375" y2="47.2773625" width="0.1524" layer="1"/>
+<wire x1="19.57659375" y1="47.2773625" x2="18.864278125" y2="47.2773625" width="0.1524" layer="1"/>
+<wire x1="20.33316875" y1="47.3356" x2="19.63483125" y2="47.3356" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$1">
+<contactref element="USBC1" pad="A5"/>
+<contactref element="R2" pad="1"/>
+<wire x1="18.71091875" y1="46.246771875" x2="18.802465625" y2="46.155225" width="0.1524" layer="1"/>
+<wire x1="20.99" y1="44.75" x2="20.99" y2="44.685" width="0.1524" layer="1"/>
+<wire x1="20.003240625" y1="46.286771875" x2="18.75091875" y2="46.286771875" width="0.1524" layer="1"/>
+<wire x1="18.71091875" y1="46.246771875" x2="18.75091875" y2="46.286771875" width="0.1524" layer="1"/>
+<wire x1="20.85" y1="44.75" x2="20.99" y2="44.75" width="0.1524" layer="1"/>
+<wire x1="20.43983125" y1="45.85018125" x2="20.43983125" y2="45.16016875" width="0.1524" layer="1"/>
+<wire x1="20.43983125" y1="45.16016875" x2="20.85" y2="44.75" width="0.1524" layer="1"/>
+<wire x1="20.003240625" y1="46.286771875" x2="20.43983125" y2="45.85018125" width="0.1524" layer="1"/>
+</signal>
+<signal name="+3V3">
+<contactref element="3V2" pad="TP"/>
+<contactref element="R1" pad="2"/>
+<contactref element="C5" pad="1"/>
+<contactref element="C4" pad="1"/>
+<contactref element="ST1" pad="17"/>
+<contactref element="L3" pad="1"/>
+<contactref element="C13" pad="1"/>
+<contactref element="C6" pad="1"/>
+<contactref element="ST1" pad="1"/>
+<contactref element="ST1" pad="5"/>
+<wire x1="27.8" y1="47.54" x2="29.25" y2="47.54" width="0.2032" layer="1"/>
+<wire x1="29.25" y1="47.54" x2="30.38" y2="46.41" width="0.2032" layer="1"/>
+<wire x1="30.38" y1="46.41" x2="31.245" y2="45.545" width="0.2032" layer="1"/>
+<via x="27.98" y="43.41" extent="1-16" drill="0.35"/>
+<wire x1="29.66" y1="42.89" x2="29.46" y2="42.89" width="0.254" layer="16"/>
+<wire x1="22.105" y1="48.3" x2="22.127171875" y2="49.1163125" width="0.254" layer="1"/>
+<wire x1="22.341059375" y1="49.04" x2="22.125" y2="49.225" width="0.254" layer="1"/>
+<wire x1="22.341059375" y1="49.04" x2="23.1" y2="49.04" width="0.254" layer="1"/>
+<wire x1="22.099996875" y1="49.289996875" x2="22.55" y2="49.74" width="0.254" layer="1"/>
+<wire x1="22.55" y1="49.74" x2="22.9" y2="50.09" width="0.254" layer="1"/>
+<wire x1="22.125" y1="49.225" x2="22.185" y2="49.225" width="0.254" layer="1"/>
+<via x="23.28" y="50.59" extent="1-16" drill="0.35"/>
+<wire x1="23.61" y1="48.13" x2="23.28" y2="48.46" width="0.254" layer="16"/>
+<wire x1="23.28" y1="50.59" x2="23.28" y2="48.46" width="0.254" layer="16"/>
+<wire x1="23.61" y1="48.13" x2="23.61" y2="43.74" width="0.254" layer="16"/>
+<wire x1="23.28" y1="50.325" x2="22.18" y2="49.225" width="0.254" layer="1"/>
+<wire x1="22.125" y1="49.225" x2="22.18" y2="49.225" width="0.254" layer="1"/>
+<wire x1="23.28" y1="50.59" x2="23.28" y2="50.325" width="0.254" layer="1"/>
+<contactref element="Z1" pad="P$5"/>
+<wire x1="21.70376875" y1="48.04376875" x2="22.10465625" y2="48.212234375" width="0.254" layer="1"/>
+<wire x1="22.10465625" y1="48.212234375" x2="22.105" y2="48.3" width="0.254" layer="1"/>
+<wire x1="22.127171875" y1="49.1163125" x2="22.125" y2="49.225" width="0.254" layer="1"/>
+<wire x1="22.125" y1="49.225" x2="22.099996875" y2="49.289996875" width="0.254" layer="1"/>
+<contactref element="ST1" pad="31"/>
+<wire x1="26.7" y1="44.94" x2="26.6357" y2="44.9257" width="0.1524" layer="1"/>
+<wire x1="31.245" y1="43.64" x2="31.245" y2="44.49" width="0.254" layer="1"/>
+<contactref element="N1" pad="P2"/>
+<contactref element="N1" pad="P1"/>
+<wire x1="24.245" y1="51.63" x2="22.9" y2="50.285" width="0.254" layer="1"/>
+<wire x1="22.9" y1="50.285" x2="22.9" y2="50.09" width="0.254" layer="1"/>
+<wire x1="43.986" y1="50.57" x2="43.986" y2="50.07" width="0.3048" layer="1"/>
+<wire x1="21.1" y1="47.44" x2="21.96" y2="48.3" width="0.254" layer="1"/>
+<wire x1="21.96" y1="48.3" x2="22.105" y2="48.3" width="0.254" layer="1"/>
+<contactref element="C3" pad="1"/>
+<contactref element="C7" pad="1"/>
+<contactref element="C8" pad="1"/>
+<contactref element="C9" pad="1"/>
+<wire x1="26.7" y1="44.94" x2="26.7" y2="43.68" width="0.254" layer="1"/>
+<wire x1="31.245" y1="43.64" x2="31.22" y2="42.89" width="0.254" layer="1"/>
+<wire x1="31.22" y1="42.89" x2="31.365" y2="42.77" width="0.254" layer="1"/>
+<wire x1="31.345" y1="41.9" x2="31.32" y2="42.75" width="0.254" layer="1"/>
+<wire x1="31.32" y1="42.75" x2="31.365" y2="42.77" width="0.254" layer="1"/>
+<wire x1="22.165" y1="50.99" x2="22.14" y2="50.17" width="0.2" layer="1"/>
+<wire x1="22.14" y1="50.17" x2="22.155" y2="50.16" width="0.2" layer="1"/>
+<wire x1="22.155" y1="50.16" x2="22.55" y2="49.74" width="0.2" layer="1"/>
+<wire x1="44.57" y1="45.29" x2="44.57" y2="48.82" width="0.3048" layer="1"/>
+<wire x1="44.57" y1="48.82" x2="43.986" y2="49.404" width="0.3048" layer="1"/>
+<wire x1="43.986" y1="50.07" x2="43.986" y2="49.404" width="0.3048" layer="1"/>
+<wire x1="43.9388" y1="50.59" x2="43.9388" y2="50.11590625" width="0.3048" layer="1"/>
+<wire x1="43.986" y1="50.57" x2="43.9588" y2="50.57" width="0.1524" layer="1"/>
+<wire x1="43.9588" y1="50.57" x2="43.9388" y2="50.59" width="0.1524" layer="1"/>
+<wire x1="27.98" y1="43.41" x2="28.5" y2="42.89" width="0.3048" layer="16"/>
+<wire x1="28.5" y1="42.89" x2="29.66" y2="42.89" width="0.3048" layer="16"/>
+<wire x1="26.7" y1="43.68" x2="26.97" y2="43.41" width="0.254" layer="1"/>
+<wire x1="26.97" y1="43.41" x2="27.98" y2="43.41" width="0.254" layer="1"/>
+<wire x1="27.98" y1="43.41" x2="28.59" y2="42.8" width="0.254" layer="1"/>
+<wire x1="28.59" y1="42.8" x2="28.59" y2="41.34" width="0.254" layer="1"/>
+<wire x1="28.59" y1="41.34" x2="31.36" y2="41.34" width="0.254" layer="1"/>
+<wire x1="31.36" y1="41.34" x2="31.36" y2="41.885" width="0.254" layer="1"/>
+<wire x1="31.36" y1="41.885" x2="31.345" y2="41.9" width="0.1524" layer="1"/>
+<wire x1="31.245" y1="44.49" x2="31.245" y2="45.545" width="0.2032" layer="1"/>
+<wire x1="27.8" y1="45.54" x2="29.51" y2="45.54" width="0.2032" layer="1"/>
+<wire x1="29.51" y1="45.54" x2="30.38" y2="46.41" width="0.2032" layer="1"/>
+<wire x1="27.84" y1="42.475" x2="27.84" y2="43.27" width="0.1524" layer="1"/>
+<wire x1="27.84" y1="43.27" x2="27.98" y2="43.41" width="0.1524" layer="1"/>
+<wire x1="27.3465125" y1="41.9815125" x2="27.84" y2="42.475" width="0.1524" layer="1"/>
+<via x="42.67" y="43.61" extent="1-16" drill="0.35"/>
+<wire x1="29.46" y1="42.89" x2="29.56" y2="42.79" width="0.3048" layer="16"/>
+<wire x1="29.56" y1="42.79" x2="29.64" y2="42.71" width="0.3048" layer="16"/>
+<wire x1="29.64" y1="42.71" x2="41.77" y2="42.71" width="0.3048" layer="16"/>
+<wire x1="41.77" y1="42.71" x2="42.67" y2="43.61" width="0.3048" layer="16"/>
+<wire x1="42.67" y1="43.61" x2="42.89" y2="43.61" width="0.1524" layer="1"/>
+<wire x1="44.57" y1="45.29" x2="42.89" y2="43.61" width="0.3048" layer="1"/>
+<wire x1="23.61" y1="43.74" x2="23.61" y2="43.689475" width="0.1524" layer="16"/>
+<wire x1="23.61" y1="43.689475" x2="24.7128" y2="42.586675" width="0.3048" layer="16"/>
+<wire x1="24.7128" y1="42.586675" x2="24.7128" y2="41.32" width="0.3048" layer="16"/>
+<wire x1="24.7128" y1="41.32" x2="28.09" y2="41.32" width="0.3048" layer="16"/>
+<wire x1="28.09" y1="41.32" x2="29.56" y2="42.79" width="0.3048" layer="16"/>
+</signal>
+<signal name="N$2">
+<contactref element="R1" pad="1"/>
+<contactref element="L1" pad="P$4"/>
+<wire x1="27.84" y1="41.225" x2="27.89736875" y2="41.16763125" width="0.1524" layer="1"/>
+<wire x1="27.89736875" y1="41.16763125" x2="27.89736875" y2="41" width="0.1524" layer="1"/>
+<wire x1="28.46374375" y1="41.0352" x2="31.48625625" y2="41.0352" width="0.1524" layer="1"/>
+<wire x1="27.84" y1="41.225" x2="28.27394375" y2="41.225" width="0.1524" layer="1"/>
+<wire x1="28.27394375" y1="41.225" x2="28.46374375" y2="41.0352" width="0.1524" layer="1"/>
+<wire x1="31.48625625" y1="41.0352" x2="35.7378" y2="45.28674375" width="0.1524" layer="1"/>
+<wire x1="35.7378" y1="45.28674375" x2="35.7378" y2="46.87365" width="0.1524" layer="1"/>
+<wire x1="35.7378" y1="46.87365" x2="35.36" y2="47.25145" width="0.1524" layer="1"/>
+<wire x1="35.36" y1="47.25145" x2="35.36" y2="47.45" width="0.1524" layer="1"/>
+</signal>
+<signal name="SWCLK">
+<contactref element="SWCLK2" pad="TP"/>
+<contactref element="ST1" pad="24"/>
+<via x="22.686" y="44.58" extent="1-16" drill="0.35"/>
+<wire x1="22.686" y1="44.58" x2="22.636" y2="44.63" width="0.1524" layer="16"/>
+<wire x1="22.944" y1="45.384" x2="22.944" y2="44.838" width="0.1524" layer="1"/>
+<wire x1="22.686" y1="44.58" x2="22.944" y2="44.838" width="0.1524" layer="1"/>
+<wire x1="22.944" y1="45.384" x2="23.1" y2="45.54" width="0.1524" layer="1"/>
+<wire x1="23.65" y1="42.34" x2="22.98" y2="43.01" width="0.254" layer="16"/>
+<wire x1="22.98" y1="43.046" x2="22.98" y2="43.01" width="0.254" layer="16"/>
+<wire x1="22.98" y1="43.046" x2="22.686" y2="43.34" width="0.254" layer="16"/>
+<wire x1="22.686" y1="43.34" x2="22.686" y2="44.58" width="0.254" layer="16"/>
+</signal>
+<signal name="S$5">
+<contactref element="ST1" pad="29"/>
+<wire x1="25.6786" y1="44.9274125" x2="25.7" y2="44.94" width="0.1524" layer="1"/>
+<wire x1="25.7" y1="44.94" x2="25.698465625" y2="44.938465625" width="0.1524" layer="1"/>
+<contactref element="C23" pad="1"/>
+<wire x1="23.962" y1="43.02" x2="23.962" y2="43.382" width="0.1524" layer="1"/>
+<wire x1="25.76" y1="44.1" x2="25.76" y2="44.8460125" width="0.1016" layer="1"/>
+<wire x1="25.76" y1="44.8460125" x2="25.6786" y2="44.9274125" width="0.1524" layer="1"/>
+<wire x1="23.962" y1="43.02" x2="25.042" y2="44.1" width="0.1016" layer="1"/>
+<wire x1="25.042" y1="44.1" x2="25.76" y2="44.1" width="0.1016" layer="1"/>
+</signal>
+<signal name="STX-&gt;">
+</signal>
+<signal name="SWDIO">
+<contactref element="ST1" pad="23"/>
+<contactref element="SWDIO2" pad="TP"/>
+<via x="19.22" y="39.94" extent="1-16" drill="0.35"/>
+<wire x1="19.22" y1="39.94" x2="18.6" y2="39.94" width="0.1524" layer="16"/>
+<wire x1="18.16" y1="40.38" x2="18.6" y2="39.94" width="0.1524" layer="16"/>
+<wire x1="22.11" y1="43.74" x2="19.22" y2="40.85" width="0.1524" layer="1"/>
+<wire x1="19.22" y1="40.85" x2="19.22" y2="39.94" width="0.1524" layer="1"/>
+<wire x1="22.4903" y1="45.41635" x2="22.4903" y2="45.6803" width="0.1524" layer="1"/>
+<wire x1="22.11" y1="45.03605" x2="22.4903" y2="45.41635" width="0.1524" layer="1"/>
+<wire x1="22.85" y1="46.04" x2="23.1" y2="46.04" width="0.1524" layer="1"/>
+<wire x1="22.11" y1="43.74" x2="22.11" y2="45.03605" width="0.1524" layer="1"/>
+<wire x1="22.4903" y1="45.6803" x2="22.85" y2="46.04" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$3">
+<contactref element="ST1" pad="8"/>
+<contactref element="L1" pad="P$2"/>
+<wire x1="27.8" y1="49.04" x2="28.54" y2="49.04" width="0.1524" layer="1"/>
+<wire x1="32.71" y1="48.49" x2="29.09" y2="48.49" width="0.1524" layer="1"/>
+<wire x1="34.51" y1="46.69" x2="34.51" y2="46.6" width="0.1524" layer="1"/>
+<wire x1="28.54" y1="49.04" x2="29.09" y2="48.49" width="0.1524" layer="1"/>
+<wire x1="34.51" y1="46.6" x2="34.49" y2="46.62" width="0.1524" layer="1"/>
+<wire x1="34.49" y1="46.62" x2="33.98" y2="46.62" width="0.1524" layer="1"/>
+<wire x1="33.98" y1="46.62" x2="33.79" y2="46.81" width="0.1524" layer="1"/>
+<wire x1="33.79" y1="47.41" x2="32.71" y2="48.49" width="0.1524" layer="1"/>
+<wire x1="33.79" y1="46.81" x2="33.79" y2="47.41" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$4">
+<contactref element="ST1" pad="9"/>
+<wire x1="27.2" y1="49.64" x2="27.2" y2="50.04" width="0.1524" layer="1"/>
+<contactref element="L1" pad="P$1"/>
+<wire x1="27.2" y1="50.04" x2="28.47" y2="50.04" width="0.1524" layer="1"/>
+<wire x1="28.47" y1="50.04" x2="29.22" y2="49.29" width="0.1524" layer="1"/>
+<wire x1="29.22" y1="49.29" x2="29.22" y2="49.02" width="0.1524" layer="1"/>
+<wire x1="32.94" y1="49.02" x2="34.51" y2="47.45" width="0.1524" layer="1"/>
+<wire x1="29.22" y1="49.02" x2="32.94" y2="49.02" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$5">
+<contactref element="ST1" pad="7"/>
+<contactref element="L1" pad="P$3"/>
+<wire x1="27.8" y1="48.54" x2="28.35" y2="48.54" width="0.1524" layer="1"/>
+<wire x1="28.35" y1="48.54" x2="28.8" y2="48.09" width="0.1524" layer="1"/>
+<wire x1="28.8" y1="48.09" x2="32.31" y2="48.09" width="0.1524" layer="1"/>
+<wire x1="32.31" y1="48.09" x2="33.5" y2="46.9" width="0.1524" layer="1"/>
+<wire x1="33.5" y1="46.9" x2="33.5" y2="45.63" width="0.1524" layer="1"/>
+<wire x1="33.5" y1="45.63" x2="35.39" y2="45.63" width="0.1524" layer="1"/>
+<wire x1="35.39" y1="45.63" x2="35.39" y2="46.57" width="0.1524" layer="1"/>
+<wire x1="35.39" y1="46.57" x2="35.36" y2="46.6" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$6">
+</signal>
+<signal name="SCLK">
+<contactref element="N1" pad="P7"/>
+<contactref element="ST1" pad="11"/>
+<wire x1="40.986" y1="51.57" x2="40.926" y2="51.63" width="0.1524" layer="1"/>
+<wire x1="40.986" y1="51.57" x2="40.437" y2="51.57" width="0.1524" layer="1"/>
+<wire x1="40.437" y1="51.57" x2="40.367" y2="51.64" width="0.1524" layer="1"/>
+<wire x1="40.257" y1="51.64" x2="40.367" y2="51.64" width="0.1524" layer="1"/>
+<via x="40.257" y="51.64" extent="1-16" drill="0.35"/>
+<via x="39.37" y="50.3992" extent="1-16" drill="0.35"/>
+<wire x1="40.257" y1="51.64" x2="39.37" y2="51.64" width="0.1524" layer="16"/>
+<wire x1="39.37" y1="50.3992" x2="39.37" y2="51.64" width="0.1524" layer="16"/>
+<wire x1="27.0885125" y1="50.9536" x2="26.2" y2="50.0650875" width="0.1524" layer="1"/>
+<wire x1="26.2" y1="49.64" x2="26.2" y2="50.0650875" width="0.1524" layer="1"/>
+<wire x1="39.37" y1="50.3992" x2="38.8156" y2="50.9536" width="0.1524" layer="1"/>
+<wire x1="38.8156" y1="50.9536" x2="27.0885125" y2="50.9536" width="0.1524" layer="1"/>
+</signal>
+<signal name="MOSI">
+<contactref element="N1" pad="P8"/>
+<contactref element="ST1" pad="13"/>
+<wire x1="40.986" y1="51.07" x2="40.946" y2="51.03" width="0.1524" layer="1"/>
+<wire x1="40.946" y1="51.03" x2="40.01055" y2="51.03" width="0.1524" layer="1"/>
+<wire x1="40.01055" y1="51.03" x2="39.4829125" y2="51.5576375" width="0.1524" layer="1"/>
+<wire x1="39.4829125" y1="51.5576375" x2="30.55695" y2="51.5576375" width="0.1524" layer="1"/>
+<wire x1="30.55695" y1="51.5576375" x2="30.5509125" y2="51.5516" width="0.1524" layer="1"/>
+<wire x1="26.6716" y1="51.5516" x2="25.2" y2="50.08" width="0.1524" layer="1"/>
+<wire x1="30.5509125" y1="51.5516" x2="26.6716" y2="51.5516" width="0.1524" layer="1"/>
+<wire x1="25.2" y1="50.08" x2="25.2" y2="49.64" width="0.1524" layer="1"/>
+</signal>
+<signal name="MISO">
+<contactref element="N1" pad="P9"/>
+<contactref element="ST1" pad="12"/>
+<wire x1="39.9821625" y1="50.62" x2="39.986" y2="50.62" width="0.1524" layer="1"/>
+<wire x1="39.9821625" y1="50.62" x2="39.3345625" y2="51.2676" width="0.1524" layer="1"/>
+<wire x1="39.3345625" y1="51.2676" x2="26.9133" y2="51.2676" width="0.1524" layer="1"/>
+<wire x1="26.9133" y1="51.2676" x2="25.7" y2="50.0543" width="0.1524" layer="1"/>
+<wire x1="25.7" y1="50.0543" x2="25.7" y2="49.64" width="0.1524" layer="1"/>
+<wire x1="39.986" y1="50.62" x2="40.036" y2="50.57" width="0.1524" layer="1"/>
+<wire x1="40.036" y1="50.57" x2="40.986" y2="50.57" width="0.1524" layer="1"/>
+</signal>
+<signal name="AMS_CS1">
+<contactref element="N1" pad="P6"/>
+<contactref element="ST1" pad="14"/>
+<wire x1="24.7" y1="50.24" x2="24.7" y2="49.64" width="0.1524" layer="1"/>
+<wire x1="26.6814" y1="53.3914" x2="26.87" y2="53.58" width="0.1524" layer="1"/>
+<wire x1="40.986" y1="52.07" x2="40.74" y2="52.07" width="0.1524" layer="1"/>
+<wire x1="40.74" y1="52.07" x2="40.66" y2="52.07" width="0.1524" layer="1"/>
+<wire x1="40.55" y1="52.18" x2="40.66" y2="52.07" width="0.1524" layer="1"/>
+<wire x1="26.40365" y1="51.7122" x2="26.1722" y2="51.7122" width="0.1524" layer="1"/>
+<wire x1="26.6814" y1="53.3914" x2="26.6814" y2="51.98995" width="0.1524" layer="1"/>
+<wire x1="26.6814" y1="51.98995" x2="26.40365" y2="51.7122" width="0.1524" layer="1"/>
+<wire x1="26.1722" y1="51.7122" x2="24.7" y2="50.24" width="0.1524" layer="1"/>
+<wire x1="27.88" y1="53.58" x2="27.82" y2="53.58" width="0.1524" layer="1"/>
+<wire x1="27.82" y1="53.58" x2="26.87" y2="53.58" width="0.1524" layer="1"/>
+<wire x1="40.53806875" y1="52.07" x2="40.46526875" y2="52.1428" width="0.1524" layer="1"/>
+<wire x1="40.53806875" y1="52.07" x2="40.74" y2="52.07" width="0.1524" layer="1"/>
+<wire x1="29.5583625" y1="51.8416375" x2="27.82" y2="53.58" width="0.1524" layer="1"/>
+<wire x1="39.558125" y1="51.8416375" x2="29.5583625" y2="51.8416375" width="0.1524" layer="1"/>
+<wire x1="39.8592875" y1="52.1428" x2="39.558125" y2="51.8416375" width="0.1524" layer="1"/>
+<wire x1="40.46526875" y1="52.1428" x2="39.8592875" y2="52.1428" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$8">
+<contactref element="N1" pad="P4"/>
+<contactref element="C15" pad="2"/>
+<contactref element="C14" pad="2"/>
+<wire x1="43.986" y1="51.57" x2="44.016" y2="51.57" width="0.1524" layer="1"/>
+<wire x1="44.82" y1="51.695" x2="45.766040625" y2="51.67" width="0.1524" layer="1"/>
+<via x="44.08" y="53.8" extent="1-16" drill="0.35"/>
+<wire x1="44.96425625" y1="51.52574375" x2="44.82" y2="51.695" width="0.1524" layer="1"/>
+<wire x1="45.59" y1="51.695" x2="44.82" y2="51.695" width="0.1524" layer="1"/>
+<wire x1="45.766040625" y1="51.67" x2="44.85474375" y2="53.02525625" width="0.1524" layer="1"/>
+<wire x1="44.08" y1="53.8" x2="44.85474375" y2="53.02525625" width="0.1524" layer="1"/>
+<wire x1="43.986" y1="51.57" x2="44.086" y2="51.67" width="0.1524" layer="1"/>
+<wire x1="44.086" y1="51.67" x2="44.82" y2="51.695" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$9">
+<contactref element="N1" pad="P3"/>
+<wire x1="43.9888" y1="51.0728" x2="43.986" y2="51.07" width="0.1524" layer="1"/>
+<contactref element="C15" pad="1"/>
+<contactref element="C14" pad="1"/>
+<wire x1="45.59" y1="50.445" x2="44.82" y2="50.445" width="0.1524" layer="1"/>
+<via x="43.333428125" y="42.05625625" extent="1-16" drill="0.35"/>
+<wire x1="45.5102" y1="50.3867625" x2="45.5102" y2="44.123028125" width="0.25" layer="1"/>
+<wire x1="45.5102" y1="44.123028125" x2="43.493428125" y2="42.10625625" width="0.25" layer="1"/>
+<wire x1="43.493428125" y1="42.10625625" x2="43.383428125" y2="42.10625625" width="0.25" layer="1"/>
+<wire x1="43.383428125" y1="42.10625625" x2="43.333428125" y2="42.05625625" width="0.25" layer="1"/>
+<wire x1="45.59" y1="50.445" x2="45.5102" y2="50.3867625" width="0.1524" layer="1"/>
+<wire x1="44.82" y1="50.445" x2="44.8" y2="50.49" width="0.1524" layer="1"/>
+<wire x1="44.8" y1="50.49" x2="44.8" y2="50.77" width="0.1524" layer="1"/>
+<wire x1="44.8" y1="50.77" x2="44.4972" y2="51.0728" width="0.1524" layer="1"/>
+<wire x1="44.4972" y1="51.0728" x2="43.9888" y2="51.0728" width="0.1524" layer="1"/>
+</signal>
+<signal name="AMS_IRQ">
+<contactref element="ST1" pad="3"/>
+<wire x1="39.57" y1="44.87" x2="39.57" y2="49.44" width="0.1524" layer="1"/>
+<wire x1="39.57" y1="44.87" x2="40.73" y2="43.71" width="0.1524" layer="1"/>
+<via x="40.73" y="43.71" extent="1-16" drill="0.3"/>
+<wire x1="40.73" y1="43.71" x2="37.8313125" y2="43.71" width="0.1524" layer="16"/>
+<wire x1="36.0419125" y1="45.4994" x2="30.8506" y2="45.4994" width="0.1524" layer="16"/>
+<wire x1="37.8313125" y1="43.71" x2="36.0419125" y2="45.4994" width="0.1524" layer="16"/>
+<wire x1="29.86" y1="46.49" x2="28.671" y2="46.49" width="0.1524" layer="16"/>
+<via x="28.671" y="46.49" extent="1-16" drill="0.35"/>
+<wire x1="30.8506" y1="45.4994" x2="29.86" y2="46.49" width="0.1524" layer="16"/>
+<wire x1="28.671" y1="46.49" x2="28.621" y2="46.54" width="0.1524" layer="1"/>
+<wire x1="28.621" y1="46.54" x2="27.8" y2="46.54" width="0.1524" layer="1"/>
+<contactref element="N1" pad="P10"/>
+<wire x1="39.57" y1="49.44" x2="40.2" y2="50.07" width="0.1524" layer="1"/>
+<wire x1="40.2" y1="50.07" x2="40.986" y2="50.07" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$7">
+<wire x1="42.25" y1="54.7" x2="20.55" y2="54.7" width="0.15" layer="16"/>
+<wire x1="20.55" y1="54.7" x2="20.55" y2="39.3" width="0.15" layer="16"/>
+<wire x1="20.55" y1="39.3" x2="42.25" y2="39.3" width="0.15" layer="16"/>
+<wire x1="45.95" y1="43" x2="45.95" y2="51" width="0.15" layer="16"/>
+<wire x1="42.25" y1="39.3" x2="45.95" y2="43" width="0.15" layer="16" curve="90"/>
+<wire x1="45.95" y1="51" x2="42.25" y2="54.3952" width="0.15" layer="16"/>
+<wire x1="42.25" y1="54.7" x2="44.0853" y2="53.7553" width="0.15" layer="16"/>
+<wire x1="42.25" y1="54.3952" x2="20.8548" y2="54.3952" width="0.15" layer="16"/>
+<wire x1="20.8548" y1="54.3952" x2="20.8548" y2="39.6048" width="0.15" layer="16"/>
+<wire x1="20.8548" y1="39.6048" x2="42.25" y2="39.6048" width="0.15" layer="16"/>
+<wire x1="45.6452" y1="43" x2="45.6452" y2="50.866009375" width="0.15" layer="16"/>
+<wire x1="45.6452" y1="50.866009375" x2="42.13135" y2="54.0904" width="0.15" layer="16"/>
+<wire x1="42.13135" y1="54.0904" x2="21.1596" y2="54.0904" width="0.15" layer="16"/>
+<wire x1="21.1596" y1="54.0904" x2="21.1596" y2="39.9096" width="0.15" layer="16"/>
+<wire x1="21.1596" y1="39.9096" x2="42.25" y2="39.9096" width="0.15" layer="16"/>
+<wire x1="42.25" y1="39.6048" x2="45.6452" y2="43" width="0.15" layer="16" curve="90"/>
+<wire x1="45.3404" y1="43" x2="45.3404" y2="50.73203125" width="0.15" layer="16"/>
+<wire x1="45.3404" y1="50.73203125" x2="42.012690625" y2="53.7856" width="0.15" layer="16"/>
+<wire x1="42.012690625" y1="53.7856" x2="21.4644" y2="53.7856" width="0.15" layer="16"/>
+<wire x1="21.4644" y1="53.7856" x2="21.4644" y2="40.2144" width="0.15" layer="16"/>
+<wire x1="21.4644" y1="40.2144" x2="42.25" y2="40.2144" width="0.15" layer="16"/>
+<wire x1="42.25" y1="39.9096" x2="45.3404" y2="43" width="0.15" layer="16" curve="90"/>
+<wire x1="45.0356" y1="43" x2="45.0356" y2="50.598040625" width="0.15" layer="16"/>
+<wire x1="45.0356" y1="50.598040625" x2="41.894040625" y2="53.4808" width="0.15" layer="16"/>
+<wire x1="41.894040625" y1="53.4808" x2="21.7692" y2="53.4808" width="0.15" layer="16"/>
+<wire x1="21.7692" y1="53.4808" x2="21.7692" y2="40.5192" width="0.15" layer="16"/>
+<wire x1="21.7692" y1="40.5192" x2="42.25" y2="40.5192" width="0.15" layer="16"/>
+<wire x1="42.25" y1="40.2144" x2="45.0356" y2="43" width="0.15" layer="16" curve="90"/>
+<wire x1="44.7308" y1="43" x2="44.7308" y2="50.46405" width="0.15" layer="16"/>
+<wire x1="44.7308" y1="50.46405" x2="41.775390625" y2="53.176" width="0.15" layer="16"/>
+<wire x1="41.775390625" y1="53.176" x2="22.074" y2="53.176" width="0.15" layer="16"/>
+<wire x1="22.074" y1="53.176" x2="22.074" y2="40.824" width="0.15" layer="16"/>
+<wire x1="22.074" y1="40.824" x2="42.25" y2="40.824" width="0.15" layer="16"/>
+<wire x1="42.25" y1="40.5192" x2="44.7308" y2="43" width="0.15" layer="16" curve="90"/>
+<wire x1="42.25" y1="40.824" x2="43.354759375" y2="42.086859375" width="0.15" layer="16"/>
+</signal>
+<signal name="S$2">
+<contactref element="R26" pad="2"/>
+<contactref element="ST1" pad="28"/>
+<wire x1="23.36335" y1="42.1522" x2="23.2592" y2="42.25635" width="0.1524" layer="1"/>
+<wire x1="23.2592" y1="42.25635" x2="23.2592" y2="43.78365" width="0.1016" layer="1"/>
+<wire x1="23.36335" y1="43.8878" x2="23.2592" y2="43.78365" width="0.1016" layer="1"/>
+<wire x1="25.044" y1="41.52" x2="24.4118" y2="42.1522" width="0.1016" layer="1"/>
+<wire x1="24.4118" y1="42.1522" x2="23.36335" y2="42.1522" width="0.1016" layer="1"/>
+<wire x1="25.2" y1="44.94" x2="25.2" y2="44.414" width="0.1016" layer="1"/>
+<wire x1="25.2" y1="44.414" x2="25.14" y2="44.354" width="0.1016" layer="1"/>
+<wire x1="25.14" y1="44.354" x2="24.9367875" y2="44.354" width="0.1016" layer="1"/>
+<wire x1="24.9367875" y1="44.354" x2="24.4705875" y2="43.8878" width="0.1016" layer="1"/>
+<wire x1="24.4705875" y1="43.8878" x2="23.36335" y2="43.8878" width="0.1016" layer="1"/>
+</signal>
+<signal name="S$4">
+<contactref element="R25" pad="2"/>
+<contactref element="ST1" pad="27"/>
+<wire x1="23.2581375" y1="44.1418" x2="24.2718" y2="44.1418" width="0.1016" layer="1"/>
+<wire x1="22.934" y1="41.57" x2="22.934" y2="43.8176625" width="0.1016" layer="1"/>
+<wire x1="22.934" y1="43.8176625" x2="23.2581375" y2="44.1418" width="0.1016" layer="1"/>
+<wire x1="24.7" y1="44.57" x2="24.7" y2="44.94" width="0.1016" layer="1"/>
+<wire x1="24.2718" y1="44.1418" x2="24.7" y2="44.57" width="0.1016" layer="1"/>
+</signal>
+<signal name="T1">
+<via x="35.77" y="55.5" extent="1-16" drill="0.3"/>
+<polygon width="0.1524" layer="16">
+<vertex x="22.88" y="56"/>
+<vertex x="22.88" y="57.81"/>
+<vertex x="23.88" y="58.81"/>
+<vertex x="38.45" y="58.81"/>
+<vertex x="39.14" y="58.12"/>
+<vertex x="39.14" y="56"/>
+</polygon>
+<polygon width="0.1524" layer="1" thermals="no">
+<vertex x="22.89" y="56"/>
+<vertex x="22.89" y="57.8"/>
+<vertex x="23.89" y="58.8"/>
+<vertex x="38.46" y="58.8"/>
+<vertex x="39.15" y="58.11"/>
+<vertex x="39.15" y="56"/>
+</polygon>
+<contactref element="R26" pad="1"/>
+<via x="35.76" y="52.51" extent="1-16" drill="0.35"/>
+<via x="35.8" y="50.17" extent="1-16" drill="0.35"/>
+<wire x1="35.76" y1="52.51" x2="35.8" y2="52.47" width="0.1016" layer="16"/>
+<wire x1="35.8" y1="52.47" x2="35.8" y2="50.17" width="0.1016" layer="16"/>
+<wire x1="35.8" y1="50.17" x2="36.36" y2="49.61" width="0.1016" layer="1"/>
+<wire x1="36.36" y1="49.61" x2="36.38" y2="49.61" width="0.1524" layer="1"/>
+<wire x1="36.38" y1="44.65973125" x2="32.19626875" y2="40.476" width="0.1016" layer="1"/>
+<wire x1="32.19626875" y1="40.476" x2="27.39755" y2="40.476" width="0.1016" layer="1"/>
+<wire x1="25.956" y1="41.52" x2="26.154871875" y2="41.718678125" width="0.1524" layer="1"/>
+<wire x1="27.39755" y1="40.476" x2="26.154871875" y2="41.718678125" width="0.1016" layer="1"/>
+<wire x1="36.38" y1="49.61" x2="36.38" y2="44.65973125" width="0.1016" layer="1"/>
+<wire x1="35.76" y1="52.51" x2="35.77" y2="52.52" width="0.1524" layer="1"/>
+<wire x1="35.77" y1="52.52" x2="35.77" y2="56.62" width="0.1016" layer="1"/>
+<wire x1="35.77" y1="55.5" x2="35.77" y2="56.45" width="0.1016" layer="16"/>
+<wire x1="35.8" y1="56.48" x2="35.77" y2="56.45" width="0.1524" layer="16"/>
+<wire x1="35.8" y1="56.48" x2="35.77" y2="56.62" width="0" layer="19" extent="1-16"/>
+</signal>
+<signal name="T2">
+<polygon width="0.1524" layer="16">
+<vertex x="23.03" y="38"/>
+<vertex x="39.97" y="38"/>
+<vertex x="40.97" y="37.34"/>
+<vertex x="40.97" y="35.74"/>
+<vertex x="40.4" y="35.17"/>
+<vertex x="23.6" y="35.17"/>
+</polygon>
+<polygon width="0.1524" layer="1" thermals="no">
+<vertex x="23.03" y="38"/>
+<vertex x="39.97" y="38"/>
+<vertex x="40.97" y="37.37"/>
+<vertex x="40.97" y="35.77"/>
+<vertex x="40.4" y="35.2"/>
+<vertex x="23.6" y="35.2"/>
+</polygon>
+<via x="25.3" y="38.42" extent="1-16" drill="0.3"/>
+<contactref element="R25" pad="1"/>
+<wire x1="25.3" y1="39.01266875" x2="25.3" y2="38.97" width="0.1016" layer="1"/>
+<wire x1="25.3" y1="38.97" x2="25.3" y2="37.46" width="0.1016" layer="1"/>
+<wire x1="25.3" y1="38.42" x2="25.3" y2="37.52" width="0.1016" layer="16"/>
+<wire x1="25.3" y1="38.97" x2="23.846" y2="40.424" width="0.1016" layer="1"/>
+<wire x1="23.846" y1="40.424" x2="23.846" y2="41.57" width="0.1016" layer="1"/>
+<wire x1="25.3" y1="37.52" x2="25.3" y2="37.46" width="0" layer="19" extent="1-16"/>
+</signal>
+</signals>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8FF0000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
+</board>
+</drawing>
+<compatibility>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports Fusion synchronisation.
+This feature will not be available in this version and saving
+the document will break the link to the Fusion PCB feature.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>

--- a/solo/USB-C-touch.sch
+++ b/solo/USB-C-touch.sch
@@ -1,0 +1,2888 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.5.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="no"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="no"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="no"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="yes" active="yes"/>
+</layers>
+<schematic xreflabel="%F%N/%S.%C%R" xrefpart="/%S.%C%R">
+<libraries>
+<library name="supply2" urn="urn:adsk.eagle:library:372">
+<description>&lt;b&gt;Supply Symbols&lt;/b&gt;&lt;p&gt;
+GND, VCC, 0V, +5V, -5V, etc.&lt;p&gt;
+Please keep in mind, that these devices are necessary for the
+automatic wiring of the supply signals.&lt;p&gt;
+The pin name defined in the symbol is identical to the net which is to be wired automatically.&lt;p&gt;
+In this library the device names are the same as the pin names of the symbols, therefore the correct signal names appear next to the supply symbols in the schematic.&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+</packages>
+<symbols>
+<symbol name="PE" urn="urn:adsk.eagle:symbol:26992/1" library_version="2">
+<wire x1="-1.27" y1="-0.762" x2="1.27" y2="-0.762" width="0.254" layer="94"/>
+<wire x1="-0.635" y1="-1.524" x2="0.635" y2="-1.524" width="0.254" layer="94"/>
+<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.254" layer="94"/>
+<text x="-4.445" y="-4.699" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="PE" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PE" urn="urn:adsk.eagle:component:27038/1" prefix="SUPPLY" library_version="2">
+<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
+<gates>
+<gate name="PE" symbol="PE" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="supply1" urn="urn:adsk.eagle:library:371">
+<description>&lt;b&gt;Supply Symbols&lt;/b&gt;&lt;p&gt;
+ GND, VCC, 0V, +5V, -5V, etc.&lt;p&gt;
+ Please keep in mind, that these devices are necessary for the
+ automatic wiring of the supply signals.&lt;p&gt;
+ The pin name defined in the symbol is identical to the net which is to be wired automatically.&lt;p&gt;
+ In this library the device names are the same as the pin names of the symbols, therefore the correct signal names appear next to the supply symbols in the schematic.&lt;p&gt;
+ &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+</packages>
+<symbols>
+<symbol name="+5V" urn="urn:adsk.eagle:symbol:26929/1" library_version="1">
+<wire x1="1.27" y1="-1.905" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
+<text x="-2.54" y="-5.08" size="1.778" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="+5V" x="0" y="-2.54" visible="off" length="short" direction="sup" rot="R90"/>
+</symbol>
+<symbol name="+3V3" urn="urn:adsk.eagle:symbol:26950/1" library_version="1">
+<wire x1="1.27" y1="-1.905" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
+<text x="-2.54" y="-5.08" size="1.778" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="+3V3" x="0" y="-2.54" visible="off" length="short" direction="sup" rot="R90"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="+5V" urn="urn:adsk.eagle:component:26963/1" prefix="P+" library_version="1">
+<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
+<gates>
+<gate name="1" symbol="+5V" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="+3V3" urn="urn:adsk.eagle:component:26981/1" prefix="+3V3" library_version="1">
+<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="+3V3" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="efm-fido" urn="urn:adsk.eagle:library:4245354">
+<packages>
+<package name="R0402" urn="urn:adsk.eagle:footprint:4245803/6" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;RESISTOR&lt;/b&gt;</description>
+<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.1524" layer="51"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.1524" layer="51"/>
+<wire x1="-1.073" y1="0.383" x2="1.073" y2="0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="0.383" x2="1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="-0.383" x2="-1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="-1.073" y1="-0.383" x2="-1.073" y2="0.383" width="0.0508" layer="39"/>
+<smd name="1" x="-0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<smd name="2" x="0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<text x="-0.635" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
+<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<rectangle x1="-0.9" y1="-0.35" x2="-0.35" y2="0.35" layer="29"/>
+<rectangle x1="0.35" y1="-0.35" x2="0.9" y2="0.35" layer="29"/>
+</package>
+<package name="DX07P024AJ5R1500" urn="urn:adsk.eagle:footprint:5621084/5" library_version="53">
+<polygon width="0.1" layer="1">
+<vertex x="0.55008125" y="2.193890625"/>
+<vertex x="0.55008125" y="3.293890625"/>
+<vertex x="-0.24991875" y="3.293890625"/>
+<vertex x="-0.24991875" y="2.193890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="0.96508125" y="1.543890625"/>
+<vertex x="0.96508125" y="0.293890625"/>
+<vertex x="0.55508125" y="0.293890625"/>
+<vertex x="0.55508125" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="1.96508125" y="1.543890625"/>
+<vertex x="1.96508125" y="0.293890625"/>
+<vertex x="1.70508125" y="0.293890625"/>
+<vertex x="1.70508125" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="2.46508125" y="1.543890625"/>
+<vertex x="2.46508125" y="0.293890625"/>
+<vertex x="2.20508125" y="0.293890625"/>
+<vertex x="2.20508125" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="2.96508125" y="1.543890625"/>
+<vertex x="2.96508125" y="0.293890625"/>
+<vertex x="2.70508125" y="0.293890625"/>
+<vertex x="2.70508125" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="3.46508125" y="1.543890625"/>
+<vertex x="3.46508125" y="0.293890625"/>
+<vertex x="3.20508125" y="0.293890625"/>
+<vertex x="3.20508125" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="3.96508125" y="0.293890625"/>
+<vertex x="3.96508125" y="1.543890625"/>
+<vertex x="3.70508125" y="1.543890625"/>
+<vertex x="3.70508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="4.46508125" y="0.293890625"/>
+<vertex x="4.46508125" y="1.543890625"/>
+<vertex x="4.20508125" y="1.543890625"/>
+<vertex x="4.20508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="4.96508125" y="0.293890625"/>
+<vertex x="4.96508125" y="1.543890625"/>
+<vertex x="4.70508125" y="1.543890625"/>
+<vertex x="4.70508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="5.46508125" y="0.293890625"/>
+<vertex x="5.46508125" y="1.543890625"/>
+<vertex x="5.20508125" y="1.543890625"/>
+<vertex x="5.20508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="5.96508125" y="0.293890625"/>
+<vertex x="5.96508125" y="1.543890625"/>
+<vertex x="5.70508125" y="1.543890625"/>
+<vertex x="5.70508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="6.61508125" y="0.293890625"/>
+<vertex x="6.61508125" y="1.543890625"/>
+<vertex x="6.20508125" y="1.543890625"/>
+<vertex x="6.20508125" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="7.65008125" y="2.193890625"/>
+<vertex x="7.65008125" y="3.293890625"/>
+<vertex x="6.81008125" y="3.293890625"/>
+<vertex x="6.81008125" y="2.193890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="6.82491875" y="2.193890625"/>
+<vertex x="6.82491875" y="3.293890625"/>
+<vertex x="7.64991875" y="3.293890625"/>
+<vertex x="7.64991875" y="2.193890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="6.81491875" y="1.893890625"/>
+<vertex x="6.81491875" y="0.143890625"/>
+<vertex x="7.17491875" y="0.143890625"/>
+<vertex x="7.17491875" y="1.893890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="6.20991875" y="1.543890625"/>
+<vertex x="6.20991875" y="0.293890625"/>
+<vertex x="6.61991875" y="0.293890625"/>
+<vertex x="6.61991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="5.70991875" y="1.543890625"/>
+<vertex x="5.70991875" y="0.293890625"/>
+<vertex x="5.96991875" y="0.293890625"/>
+<vertex x="5.96991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="5.20991875" y="1.543890625"/>
+<vertex x="5.20991875" y="0.293890625"/>
+<vertex x="5.46991875" y="0.293890625"/>
+<vertex x="5.46991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="4.70991875" y="1.543890625"/>
+<vertex x="4.70991875" y="0.293890625"/>
+<vertex x="4.96991875" y="0.293890625"/>
+<vertex x="4.96991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="4.20991875" y="1.543890625"/>
+<vertex x="4.20991875" y="0.293890625"/>
+<vertex x="4.46991875" y="0.293890625"/>
+<vertex x="4.46991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="3.70991875" y="1.543890625"/>
+<vertex x="3.70991875" y="0.293890625"/>
+<vertex x="3.96991875" y="0.293890625"/>
+<vertex x="3.96991875" y="1.543890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="3.20991875" y="0.293890625"/>
+<vertex x="3.20991875" y="1.543890625"/>
+<vertex x="3.46991875" y="1.543890625"/>
+<vertex x="3.46991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="2.70991875" y="0.293890625"/>
+<vertex x="2.70991875" y="1.543890625"/>
+<vertex x="2.96991875" y="1.543890625"/>
+<vertex x="2.96991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="2.20991875" y="0.293890625"/>
+<vertex x="2.20991875" y="1.543890625"/>
+<vertex x="2.46991875" y="1.543890625"/>
+<vertex x="2.46991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="1.70991875" y="0.293890625"/>
+<vertex x="1.70991875" y="1.543890625"/>
+<vertex x="1.96991875" y="1.543890625"/>
+<vertex x="1.96991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="1.20991875" y="0.293890625"/>
+<vertex x="1.20991875" y="1.543890625"/>
+<vertex x="1.46991875" y="1.543890625"/>
+<vertex x="1.46991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="0.55991875" y="0.293890625"/>
+<vertex x="0.55991875" y="1.543890625"/>
+<vertex x="0.96991875" y="1.543890625"/>
+<vertex x="0.96991875" y="0.293890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="0.00491875" y="1.893890625"/>
+<vertex x="0.00491875" y="0.143890625"/>
+<vertex x="0.36491875" y="0.143890625"/>
+<vertex x="0.36491875" y="1.893890625"/>
+</polygon>
+<polygon width="0.1" layer="16">
+<vertex x="-0.25008125" y="2.193890625"/>
+<vertex x="-0.25008125" y="3.293890625"/>
+<vertex x="0.56491875" y="3.293890625"/>
+<vertex x="0.56491875" y="2.193890625"/>
+</polygon>
+<polygon width="0.1" layer="1">
+<vertex x="1.20491875" y="0.296390625"/>
+<vertex x="1.20491875" y="1.546390625"/>
+<vertex x="1.46491875" y="1.546390625"/>
+<vertex x="1.46491875" y="0.296390625"/>
+</polygon>
+<smd name="A12" x="0.7625" y="0.925" dx="0.35" dy="1.2" layer="1"/>
+<smd name="A11" x="1.3375" y="0.925" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A10" x="1.8375" y="0.925" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A9" x="2.3375" y="0.925" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A8" x="2.8375" y="0.925" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A7" x="3.3375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A6" x="3.8375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A5" x="4.3375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A4" x="4.8375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A3" x="5.3375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A2" x="5.8375" y="0.9125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A1" x="6.4125" y="0.9125" dx="0.35" dy="1.2" layer="1"/>
+<smd name="P_GND3" x="7" y="1.025" dx="0.3" dy="1.7" layer="1" rot="R180"/>
+<smd name="P_GND4" x="0.175" y="1.025" dx="0.3" dy="1.7" layer="1" rot="R180"/>
+<smd name="B12" x="6.4125" y="0.925" dx="0.35" dy="1.2" layer="16" rot="R180"/>
+<smd name="B11" x="5.8375" y="0.925" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B10" x="5.3375" y="0.925" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B9" x="4.8375" y="0.925" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B8" x="4.3375" y="0.925" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B7" x="3.8375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B6" x="3.3375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B5" x="2.8375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B4" x="2.3375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B3" x="1.8375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B2" x="1.3375" y="0.9125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B1" x="0.7625" y="0.9125" dx="0.35" dy="1.2" layer="16" rot="R180"/>
+<rectangle x1="-0.325" y1="2.125" x2="0.625" y2="3.35" layer="29"/>
+<rectangle x1="6.75" y1="2.125" x2="7.725" y2="3.375" layer="29"/>
+<rectangle x1="-0.325" y1="2.125" x2="0.625" y2="3.375" layer="30"/>
+<rectangle x1="6.725" y1="2.125" x2="7.725" y2="3.375" layer="30"/>
+<wire x1="-0.315" y1="1.15" x2="-0.315" y2="-0.55" width="0.1" layer="47"/>
+<wire x1="-0.315" y1="-0.55" x2="-0.315" y2="-1.15" width="0.1" layer="47"/>
+<wire x1="-0.315" y1="-1.15" x2="7.485" y2="-1.15" width="0.1" layer="47"/>
+<wire x1="7.485" y1="-1.15" x2="7.485" y2="-0.55" width="0.1" layer="47"/>
+<wire x1="7.485" y1="-0.55" x2="7.485" y2="1.75" width="0.1" layer="47"/>
+<wire x1="-0.315" y1="-0.55" x2="7.485" y2="-0.55" width="0.1" layer="47"/>
+</package>
+<package name="B1,27" urn="urn:adsk.eagle:footprint:27900/1" library_version="2" library_locally_modified="yes">
+<description>&lt;b&gt;TEST PAD&lt;/b&gt;</description>
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.0024" layer="37"/>
+<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.0024" layer="37"/>
+<smd name="TP" x="0" y="0" dx="1.27" dy="1.27" layer="1" roundness="100" cream="no"/>
+<text x="-0.635" y="1.016" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-0.635" y="-0.762" size="0.0254" layer="27">&gt;VALUE</text>
+<text x="-0.635" y="-1.905" size="1" layer="37">&gt;TP_SIGNAL_NAME</text>
+</package>
+<package name="C0402" urn="urn:adsk.eagle:footprint:4894774/5" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;CAPACITOR&lt;/b&gt;</description>
+<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.1524" layer="51"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.1524" layer="51"/>
+<wire x1="-1.073" y1="0.383" x2="1.073" y2="0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="0.383" x2="1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="1.073" y1="-0.383" x2="-1.073" y2="-0.383" width="0.0508" layer="39"/>
+<wire x1="-1.073" y1="-0.383" x2="-1.073" y2="0.383" width="0.0508" layer="39"/>
+<smd name="1" x="-0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<smd name="2" x="0.625" y="0" dx="0.5" dy="0.6" layer="1" stop="no"/>
+<text x="-0.635" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
+<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+<rectangle x1="-0.9" y1="-0.35" x2="-0.35" y2="0.35" layer="29"/>
+<rectangle x1="0.35" y1="-0.35" x2="0.9" y2="0.35" layer="29"/>
+</package>
+<package name="QFN32" urn="urn:adsk.eagle:footprint:6434393/5" library_version="82">
+<description>&lt;b&gt;QFN 32&lt;/b&gt; 5 x 5 mm&lt;p&gt;
+Source: http://datasheets.maxim-ic.com/en/ds/MAX7042.pdf</description>
+<wire x1="-2.45" y1="2.45" x2="2.45" y2="2.45" width="0.1016" layer="51"/>
+<wire x1="2.45" y1="2.45" x2="2.45" y2="-2.45" width="0.1016" layer="51"/>
+<wire x1="2.45" y1="-2.45" x2="-2.45" y2="-2.45" width="0.1016" layer="51"/>
+<wire x1="-2.45" y1="-2.45" x2="-2.45" y2="2.45" width="0.1016" layer="51"/>
+<wire x1="-2.45" y1="2.05" x2="-2.45" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="-2.45" y1="2.45" x2="-2.05" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="2.05" y1="2.45" x2="2.45" y2="2.45" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="2.45" x2="2.45" y2="2.05" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="-2.05" x2="2.45" y2="-2.45" width="0.1016" layer="21"/>
+<wire x1="2.45" y1="-2.45" x2="2.05" y2="-2.45" width="0.1016" layer="21"/>
+<wire x1="-2.05" y1="-2.45" x2="-2.45" y2="-2.4" width="0.1016" layer="21"/>
+<wire x1="-2.45" y1="-2.4" x2="-2.45" y2="-2.05" width="0.1016" layer="21"/>
+<circle x="-2.425" y="2.475" radius="0.3" width="0" layer="21"/>
+<smd name="EXP" x="0" y="0" dx="0.2" dy="0.2" layer="1" roundness="20" stop="no" cream="no"/>
+<smd name="1" x="-2.35" y="1.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="2" x="-2.35" y="1.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="3" x="-2.35" y="0.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="4" x="-2.35" y="0.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="5" x="-2.35" y="-0.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="6" x="-2.35" y="-0.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="7" x="-2.35" y="-1.25" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="8" x="-2.35" y="-1.75" dx="0.6" dy="0.3" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="9" x="-1.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="10" x="-1.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="11" x="-0.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="12" x="-0.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="13" x="0.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="14" x="0.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="15" x="1.25" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="16" x="1.75" y="-2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="17" x="2.35" y="-1.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="18" x="2.35" y="-1.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="19" x="2.35" y="-0.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="20" x="2.35" y="-0.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="21" x="2.35" y="0.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="22" x="2.35" y="0.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="23" x="2.35" y="1.25" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="24" x="2.35" y="1.75" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="25" x="1.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="26" x="1.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="27" x="0.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="28" x="0.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="29" x="-0.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="30" x="-0.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="31" x="-1.25" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="32" x="-1.75" y="2.35" dx="0.6" dy="0.3" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<text x="-4.05" y="-4.35" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.8" y="3.25" size="1.27" layer="25">&gt;NAME</text>
+<rectangle x1="-0.3" y1="1.1" x2="0.3" y2="1.4" layer="31"/>
+<rectangle x1="-0.3" y1="0.6" x2="0.3" y2="0.9" layer="31"/>
+<rectangle x1="-0.3" y1="0.1" x2="0.3" y2="0.4" layer="31"/>
+<rectangle x1="-0.3" y1="-0.4" x2="0.3" y2="-0.1" layer="31"/>
+<rectangle x1="-0.3" y1="-0.9" x2="0.3" y2="-0.6" layer="31"/>
+<rectangle x1="-0.3" y1="-1.4" x2="0.3" y2="-1.1" layer="31"/>
+<rectangle x1="-1.3" y1="1.1" x2="-0.7" y2="1.4" layer="31"/>
+<rectangle x1="-1.3" y1="0.6" x2="-0.7" y2="0.9" layer="31"/>
+<rectangle x1="-1.3" y1="0.1" x2="-0.7" y2="0.4" layer="31"/>
+<rectangle x1="-1.3" y1="-0.4" x2="-0.7" y2="-0.1" layer="31"/>
+<rectangle x1="-1.3" y1="-0.9" x2="-0.7" y2="-0.6" layer="31"/>
+<rectangle x1="-1.3" y1="-1.4" x2="-0.7" y2="-1.1" layer="31"/>
+<rectangle x1="0.7" y1="1.1" x2="1.3" y2="1.4" layer="31"/>
+<rectangle x1="0.7" y1="0.6" x2="1.3" y2="0.9" layer="31"/>
+<rectangle x1="0.7" y1="0.1" x2="1.3" y2="0.4" layer="31"/>
+<rectangle x1="0.7" y1="-0.4" x2="1.3" y2="-0.1" layer="31"/>
+<rectangle x1="0.7" y1="-0.9" x2="1.3" y2="-0.6" layer="31"/>
+<rectangle x1="0.7" y1="-1.4" x2="1.3" y2="-1.1" layer="31"/>
+<rectangle x1="-2.55" y1="0.3" x2="-0.3" y2="2.55" layer="51"/>
+<rectangle x1="-0.3" y1="1.1" x2="0.3" y2="1.4" layer="1"/>
+<rectangle x1="-0.3" y1="0.6" x2="0.3" y2="0.9" layer="1"/>
+<rectangle x1="-0.3" y1="0.1" x2="0.3" y2="0.4" layer="1"/>
+<rectangle x1="-0.3" y1="-0.4" x2="0.3" y2="-0.1" layer="1"/>
+<rectangle x1="-0.3" y1="-0.9" x2="0.3" y2="-0.6" layer="1"/>
+<rectangle x1="-0.3" y1="-1.4" x2="0.3" y2="-1.1" layer="1"/>
+<rectangle x1="-1.3" y1="1.1" x2="-0.7" y2="1.4" layer="1"/>
+<rectangle x1="-1.3" y1="0.6" x2="-0.7" y2="0.9" layer="1"/>
+<rectangle x1="-1.3" y1="0.1" x2="-0.7" y2="0.4" layer="1"/>
+<rectangle x1="-1.3" y1="-0.4" x2="-0.7" y2="-0.1" layer="1"/>
+<rectangle x1="-1.3" y1="-0.9" x2="-0.7" y2="-0.6" layer="1"/>
+<rectangle x1="-1.3" y1="-1.4" x2="-0.7" y2="-1.1" layer="1"/>
+<rectangle x1="0.7" y1="1.1" x2="1.3" y2="1.4" layer="1"/>
+<rectangle x1="0.7" y1="0.6" x2="1.3" y2="0.9" layer="1"/>
+<rectangle x1="0.7" y1="0.1" x2="1.3" y2="0.4" layer="1"/>
+<rectangle x1="0.7" y1="-0.4" x2="1.3" y2="-0.1" layer="1"/>
+<rectangle x1="0.7" y1="-0.9" x2="1.3" y2="-0.6" layer="1"/>
+<rectangle x1="0.7" y1="-1.4" x2="1.3" y2="-1.1" layer="1"/>
+<polygon width="0.5" layer="29">
+<vertex x="-1.325" y="1.175"/>
+<vertex x="-1.175" y="1.325"/>
+<vertex x="1.325" y="1.325"/>
+<vertex x="1.325" y="-1.325"/>
+<vertex x="-1.325" y="-1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="1.85"/>
+<vertex x="-2.1" y="1.85"/>
+<vertex x="-2.05" y="1.8"/>
+<vertex x="-2.05" y="1.65"/>
+<vertex x="-2.55" y="1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="1.825"/>
+<vertex x="-2.175" y="1.825"/>
+<vertex x="-2.125" y="1.775"/>
+<vertex x="-2.125" y="1.675"/>
+<vertex x="-2.575" y="1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="1.35"/>
+<vertex x="-2.05" y="1.35"/>
+<vertex x="-2.05" y="1.15"/>
+<vertex x="-2.55" y="1.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="1.325"/>
+<vertex x="-2.125" y="1.325"/>
+<vertex x="-2.125" y="1.175"/>
+<vertex x="-2.575" y="1.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="0.85"/>
+<vertex x="-2.05" y="0.85"/>
+<vertex x="-2.05" y="0.65"/>
+<vertex x="-2.55" y="0.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="0.825"/>
+<vertex x="-2.125" y="0.825"/>
+<vertex x="-2.125" y="0.675"/>
+<vertex x="-2.575" y="0.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="0.35"/>
+<vertex x="-2.05" y="0.35"/>
+<vertex x="-2.05" y="0.15"/>
+<vertex x="-2.55" y="0.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="0.325"/>
+<vertex x="-2.125" y="0.325"/>
+<vertex x="-2.125" y="0.175"/>
+<vertex x="-2.575" y="0.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-0.15"/>
+<vertex x="-2.05" y="-0.15"/>
+<vertex x="-2.05" y="-0.35"/>
+<vertex x="-2.55" y="-0.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-0.175"/>
+<vertex x="-2.125" y="-0.175"/>
+<vertex x="-2.125" y="-0.325"/>
+<vertex x="-2.575" y="-0.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-0.65"/>
+<vertex x="-2.05" y="-0.65"/>
+<vertex x="-2.05" y="-0.85"/>
+<vertex x="-2.55" y="-0.85"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-0.675"/>
+<vertex x="-2.125" y="-0.675"/>
+<vertex x="-2.125" y="-0.825"/>
+<vertex x="-2.575" y="-0.825"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-1.15"/>
+<vertex x="-2.05" y="-1.15"/>
+<vertex x="-2.05" y="-1.35"/>
+<vertex x="-2.55" y="-1.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-1.175"/>
+<vertex x="-2.125" y="-1.175"/>
+<vertex x="-2.125" y="-1.325"/>
+<vertex x="-2.575" y="-1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-2.55" y="-1.85"/>
+<vertex x="-2.1" y="-1.85"/>
+<vertex x="-2.05" y="-1.8"/>
+<vertex x="-2.05" y="-1.65"/>
+<vertex x="-2.55" y="-1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-2.575" y="-1.825"/>
+<vertex x="-2.175" y="-1.825"/>
+<vertex x="-2.125" y="-1.775"/>
+<vertex x="-2.125" y="-1.675"/>
+<vertex x="-2.575" y="-1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.85" y="-2.55"/>
+<vertex x="-1.85" y="-2.1"/>
+<vertex x="-1.8" y="-2.05"/>
+<vertex x="-1.65" y="-2.05"/>
+<vertex x="-1.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.825" y="-2.575"/>
+<vertex x="-1.825" y="-2.175"/>
+<vertex x="-1.775" y="-2.125"/>
+<vertex x="-1.675" y="-2.125"/>
+<vertex x="-1.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.35" y="-2.55"/>
+<vertex x="-1.35" y="-2.05"/>
+<vertex x="-1.15" y="-2.05"/>
+<vertex x="-1.15" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.325" y="-2.575"/>
+<vertex x="-1.325" y="-2.125"/>
+<vertex x="-1.175" y="-2.125"/>
+<vertex x="-1.175" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.85" y="-2.55"/>
+<vertex x="-0.85" y="-2.05"/>
+<vertex x="-0.65" y="-2.05"/>
+<vertex x="-0.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.825" y="-2.575"/>
+<vertex x="-0.825" y="-2.125"/>
+<vertex x="-0.675" y="-2.125"/>
+<vertex x="-0.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.35" y="-2.55"/>
+<vertex x="-0.35" y="-2.05"/>
+<vertex x="-0.15" y="-2.05"/>
+<vertex x="-0.15" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.325" y="-2.575"/>
+<vertex x="-0.325" y="-2.125"/>
+<vertex x="-0.175" y="-2.125"/>
+<vertex x="-0.175" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.15" y="-2.55"/>
+<vertex x="0.15" y="-2.05"/>
+<vertex x="0.35" y="-2.05"/>
+<vertex x="0.35" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.175" y="-2.575"/>
+<vertex x="0.175" y="-2.125"/>
+<vertex x="0.325" y="-2.125"/>
+<vertex x="0.325" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.65" y="-2.55"/>
+<vertex x="0.65" y="-2.05"/>
+<vertex x="0.85" y="-2.05"/>
+<vertex x="0.85" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.675" y="-2.575"/>
+<vertex x="0.675" y="-2.125"/>
+<vertex x="0.825" y="-2.125"/>
+<vertex x="0.825" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.15" y="-2.55"/>
+<vertex x="1.15" y="-2.05"/>
+<vertex x="1.35" y="-2.05"/>
+<vertex x="1.35" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.175" y="-2.575"/>
+<vertex x="1.175" y="-2.125"/>
+<vertex x="1.325" y="-2.125"/>
+<vertex x="1.325" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.85" y="-2.55"/>
+<vertex x="1.85" y="-2.1"/>
+<vertex x="1.8" y="-2.05"/>
+<vertex x="1.65" y="-2.05"/>
+<vertex x="1.65" y="-2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.825" y="-2.575"/>
+<vertex x="1.825" y="-2.175"/>
+<vertex x="1.775" y="-2.125"/>
+<vertex x="1.675" y="-2.125"/>
+<vertex x="1.675" y="-2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-1.85"/>
+<vertex x="2.1" y="-1.85"/>
+<vertex x="2.05" y="-1.8"/>
+<vertex x="2.05" y="-1.65"/>
+<vertex x="2.55" y="-1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-1.825"/>
+<vertex x="2.175" y="-1.825"/>
+<vertex x="2.125" y="-1.775"/>
+<vertex x="2.125" y="-1.675"/>
+<vertex x="2.575" y="-1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-1.35"/>
+<vertex x="2.05" y="-1.35"/>
+<vertex x="2.05" y="-1.15"/>
+<vertex x="2.55" y="-1.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-1.325"/>
+<vertex x="2.125" y="-1.325"/>
+<vertex x="2.125" y="-1.175"/>
+<vertex x="2.575" y="-1.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-0.85"/>
+<vertex x="2.05" y="-0.85"/>
+<vertex x="2.05" y="-0.65"/>
+<vertex x="2.55" y="-0.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-0.825"/>
+<vertex x="2.125" y="-0.825"/>
+<vertex x="2.125" y="-0.675"/>
+<vertex x="2.575" y="-0.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="-0.35"/>
+<vertex x="2.05" y="-0.35"/>
+<vertex x="2.05" y="-0.15"/>
+<vertex x="2.55" y="-0.15"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="-0.325"/>
+<vertex x="2.125" y="-0.325"/>
+<vertex x="2.125" y="-0.175"/>
+<vertex x="2.575" y="-0.175"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="0.15"/>
+<vertex x="2.05" y="0.15"/>
+<vertex x="2.05" y="0.35"/>
+<vertex x="2.55" y="0.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="0.175"/>
+<vertex x="2.125" y="0.175"/>
+<vertex x="2.125" y="0.325"/>
+<vertex x="2.575" y="0.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="0.65"/>
+<vertex x="2.05" y="0.65"/>
+<vertex x="2.05" y="0.85"/>
+<vertex x="2.55" y="0.85"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="0.675"/>
+<vertex x="2.125" y="0.675"/>
+<vertex x="2.125" y="0.825"/>
+<vertex x="2.575" y="0.825"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="1.15"/>
+<vertex x="2.05" y="1.15"/>
+<vertex x="2.05" y="1.35"/>
+<vertex x="2.55" y="1.35"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="1.175"/>
+<vertex x="2.125" y="1.175"/>
+<vertex x="2.125" y="1.325"/>
+<vertex x="2.575" y="1.325"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="2.55" y="1.85"/>
+<vertex x="2.1" y="1.85"/>
+<vertex x="2.05" y="1.8"/>
+<vertex x="2.05" y="1.65"/>
+<vertex x="2.55" y="1.65"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="2.575" y="1.825"/>
+<vertex x="2.175" y="1.825"/>
+<vertex x="2.125" y="1.775"/>
+<vertex x="2.125" y="1.675"/>
+<vertex x="2.575" y="1.675"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.85" y="2.55"/>
+<vertex x="1.85" y="2.1"/>
+<vertex x="1.8" y="2.05"/>
+<vertex x="1.65" y="2.05"/>
+<vertex x="1.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.825" y="2.575"/>
+<vertex x="1.825" y="2.175"/>
+<vertex x="1.775" y="2.125"/>
+<vertex x="1.675" y="2.125"/>
+<vertex x="1.675" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="1.35" y="2.55"/>
+<vertex x="1.35" y="2.05"/>
+<vertex x="1.15" y="2.05"/>
+<vertex x="1.15" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="1.325" y="2.575"/>
+<vertex x="1.325" y="2.125"/>
+<vertex x="1.175" y="2.125"/>
+<vertex x="1.175" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.85" y="2.55"/>
+<vertex x="0.85" y="2.05"/>
+<vertex x="0.65" y="2.05"/>
+<vertex x="0.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.825" y="2.575"/>
+<vertex x="0.825" y="2.125"/>
+<vertex x="0.675" y="2.125"/>
+<vertex x="0.675" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="0.35" y="2.55"/>
+<vertex x="0.35" y="2.05"/>
+<vertex x="0.15" y="2.05"/>
+<vertex x="0.15" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="0.325" y="2.575"/>
+<vertex x="0.325" y="2.125"/>
+<vertex x="0.175" y="2.125"/>
+<vertex x="0.175" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.15" y="2.55"/>
+<vertex x="-0.15" y="2.05"/>
+<vertex x="-0.35" y="2.05"/>
+<vertex x="-0.35" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.175" y="2.575"/>
+<vertex x="-0.175" y="2.125"/>
+<vertex x="-0.325" y="2.125"/>
+<vertex x="-0.325" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-0.65" y="2.55"/>
+<vertex x="-0.65" y="2.05"/>
+<vertex x="-0.85" y="2.05"/>
+<vertex x="-0.85" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-0.675" y="2.575"/>
+<vertex x="-0.675" y="2.125"/>
+<vertex x="-0.825" y="2.125"/>
+<vertex x="-0.825" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.15" y="2.55"/>
+<vertex x="-1.15" y="2.05"/>
+<vertex x="-1.35" y="2.05"/>
+<vertex x="-1.35" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.175" y="2.575"/>
+<vertex x="-1.175" y="2.125"/>
+<vertex x="-1.325" y="2.125"/>
+<vertex x="-1.325" y="2.575"/>
+</polygon>
+<polygon width="0.1016" layer="29">
+<vertex x="-1.85" y="2.55"/>
+<vertex x="-1.85" y="2.1"/>
+<vertex x="-1.8" y="2.05"/>
+<vertex x="-1.65" y="2.05"/>
+<vertex x="-1.65" y="2.55"/>
+</polygon>
+<polygon width="0.1016" layer="31">
+<vertex x="-1.825" y="2.575"/>
+<vertex x="-1.825" y="2.175"/>
+<vertex x="-1.775" y="2.125"/>
+<vertex x="-1.675" y="2.125"/>
+<vertex x="-1.675" y="2.575"/>
+</polygon>
+<polygon width="0.127" layer="1" spacing="0.7112" pour="hatch">
+<vertex x="-1.5" y="1.5"/>
+<vertex x="1.5" y="1.5"/>
+<vertex x="1.5" y="-1.5"/>
+<vertex x="-1.5" y="-1.5"/>
+</polygon>
+</package>
+<package name="REG_NCP114AMX330TCG" urn="urn:adsk.eagle:footprint:5621085/3" library_version="66">
+<polygon width="0.001" layer="1">
+<vertex x="-0.475" y="0.65"/>
+<vertex x="-0.475" y="0.22"/>
+<vertex x="-0.375" y="0.22"/>
+<vertex x="-0.175" y="0.42"/>
+<vertex x="-0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="0.475" y="0.65"/>
+<vertex x="0.475" y="0.22"/>
+<vertex x="0.375" y="0.22"/>
+<vertex x="0.175" y="0.42"/>
+<vertex x="0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="0.475" y="-0.65"/>
+<vertex x="0.475" y="-0.22"/>
+<vertex x="0.375" y="-0.22"/>
+<vertex x="0.175" y="-0.42"/>
+<vertex x="0.175" y="-0.65"/>
+</polygon>
+<polygon width="0.001" layer="1">
+<vertex x="-0.475" y="-0.65"/>
+<vertex x="-0.175" y="-0.65"/>
+<vertex x="-0.175" y="-0.42"/>
+<vertex x="-0.475" y="-0.12"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="-0.475" y="0.65"/>
+<vertex x="-0.475" y="0.22"/>
+<vertex x="-0.375" y="0.22"/>
+<vertex x="-0.175" y="0.42"/>
+<vertex x="-0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="0.475" y="0.65"/>
+<vertex x="0.475" y="0.22"/>
+<vertex x="0.375" y="0.22"/>
+<vertex x="0.175" y="0.42"/>
+<vertex x="0.175" y="0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="0.475" y="-0.65"/>
+<vertex x="0.475" y="-0.22"/>
+<vertex x="0.375" y="-0.22"/>
+<vertex x="0.175" y="-0.42"/>
+<vertex x="0.175" y="-0.65"/>
+</polygon>
+<polygon width="0.001" layer="31">
+<vertex x="-0.475" y="-0.65"/>
+<vertex x="-0.175" y="-0.65"/>
+<vertex x="-0.175" y="-0.42"/>
+<vertex x="-0.475" y="-0.12"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="-0.525" y="0.7"/>
+<vertex x="-0.125" y="0.7"/>
+<vertex x="-0.125" y="0.4"/>
+<vertex x="-0.35" y="0.175"/>
+<vertex x="-0.525" y="0.175"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="0.525" y="-0.7"/>
+<vertex x="0.125" y="-0.7"/>
+<vertex x="0.125" y="-0.4"/>
+<vertex x="0.35" y="-0.175"/>
+<vertex x="0.525" y="-0.175"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="0.125" y="0.7"/>
+<vertex x="0.525" y="0.7"/>
+<vertex x="0.525" y="0.175"/>
+<vertex x="0.35" y="0.175"/>
+<vertex x="0.125" y="0.4"/>
+</polygon>
+<polygon width="0.001" layer="29">
+<vertex x="-0.525" y="-0.7"/>
+<vertex x="-0.125" y="-0.7"/>
+<vertex x="-0.125" y="-0.4"/>
+<vertex x="-0.475" y="-0.05"/>
+<vertex x="-0.525" y="-0.05"/>
+</polygon>
+<circle x="-0.74" y="-0.848" radius="0.14" width="0.1016" layer="21"/>
+<wire x1="-0.5" y1="0.5" x2="-0.5" y2="-0.5" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.5" x2="0.5" y2="-0.5" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.5" x2="0.5" y2="0.5" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.5" x2="-0.5" y2="0.5" width="0.1" layer="51"/>
+<wire x1="-0.762" y1="0.889" x2="-0.762" y2="-0.889" width="0.05" layer="39"/>
+<wire x1="-0.762" y1="-0.889" x2="0.762" y2="-0.889" width="0.05" layer="39"/>
+<wire x1="0.762" y1="-0.889" x2="0.762" y2="0.889" width="0.05" layer="39"/>
+<wire x1="0.762" y1="0.889" x2="-0.762" y2="0.889" width="0.05" layer="39"/>
+<text x="-0.74228125" y="0.972990625" size="0.6" layer="25">&gt;NAME</text>
+<text x="-0.742921875" y="-1.2449" size="0.306003125" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.351734375" y1="-0.351734375" x2="0.35" y2="0.35" layer="29" rot="R45"/>
+<smd name="5" x="0" y="0" dx="0.58" dy="0.58" layer="1" rot="R45" stop="no"/>
+<smd name="1" x="-0.325" y="-0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="2" x="0.325" y="-0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="3" x="0.325" y="0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+<smd name="4" x="-0.325" y="0.5" dx="0.1" dy="0.1" layer="1" stop="no" cream="no"/>
+</package>
+<package name="BZA900A" urn="urn:adsk.eagle:footprint:5621086/2" library_version="28">
+<smd name="P$1" x="-0.05" y="0" dx="0.325" dy="0.5" layer="1"/>
+<smd name="P$2" x="0.5" y="0" dx="0.3" dy="0.6" layer="1"/>
+<smd name="P$3" x="1.05" y="0" dx="0.325" dy="0.5" layer="1"/>
+<smd name="P$4" x="1" y="1.7" dx="0.4" dy="0.5" layer="1"/>
+<smd name="P$5" x="0" y="1.7" dx="0.4" dy="0.5" layer="1"/>
+<text x="-0.5" y="1.8" size="0.4064" layer="25">&gt;NAME</text>
+</package>
+<package name="MLPD3X3" urn="urn:adsk.eagle:footprint:5825737/8" library_version="82">
+<smd name="P5" x="0" y="-2.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P4" x="0" y="-2.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P3" x="0" y="-1.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P2" x="0" y="-1.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P1" x="0" y="-0.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P10" x="3" y="-0.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P9" x="3" y="-1.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P8" x="3" y="-1.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P7" x="3" y="-2.04" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P6" x="3" y="-2.54" dx="0.6" dy="0.35" layer="1" rot="R180"/>
+<smd name="P$11" x="1.6" y="-1.64" dx="0.2" dy="0.2" layer="1" rot="R180"/>
+<text x="-0.5" y="-3.04" size="0.6096" layer="25" rot="R90">&gt;NAME</text>
+<text x="4" y="-3.04" size="0.6096" layer="27" rot="R90">&gt;VALUE</text>
+<polygon width="0.127" layer="1" spacing="0.7366" pour="hatch">
+<vertex x="0.7" y="-0.4"/>
+<vertex x="2.3" y="-0.4"/>
+<vertex x="2.3" y="-2.7"/>
+<vertex x="0.7" y="-2.7"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="0.7" y="-0.4"/>
+<vertex x="2.3" y="-0.4"/>
+<vertex x="2.3" y="-2.7"/>
+<vertex x="0.7" y="-2.7"/>
+</polygon>
+<circle x="-0.5588" y="0.2286" radius="0.1626375" width="0.3556" layer="25"/>
+<rectangle x1="1.4" y1="-2.6" x2="1.6" y2="-0.5" layer="31"/>
+<rectangle x1="0.7" y1="-0.8" x2="1.3" y2="-0.6" layer="31"/>
+<rectangle x1="1.7" y1="-0.8" x2="2.3" y2="-0.6" layer="31"/>
+<rectangle x1="0.7" y1="-1.6" x2="1.3" y2="-1.3" layer="31"/>
+<rectangle x1="1.8" y1="-1.6" x2="2.3" y2="-1.3" layer="31"/>
+<rectangle x1="0.7" y1="-2.3" x2="1.3" y2="-2.1" layer="31"/>
+<rectangle x1="1.8" y1="-2.3" x2="2.3" y2="-2.1" layer="31"/>
+</package>
+<package name="WüRTH_632712000112" urn="urn:adsk.eagle:footprint:9339181/5" library_version="75">
+<smd name="A12" x="0.154525" y="1.01879375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A11" x="0.65488125" y="1.016203125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A10" x="1.158565625" y="1.023003125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A9" x="1.654875" y="1.0210125" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A8" x="2.15640625" y="1.016634375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A7" x="2.654875" y="1.016765625" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A6" x="3.15690625" y="1.021084375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A5" x="3.653228125" y="1.02091875" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A4" x="4.161096875" y="1.020959375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A3" x="4.648653125" y="1.02311875" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A2" x="5.1519375" y="1.0209" dx="0.2" dy="1.2" layer="1"/>
+<smd name="A1" x="5.6505" y="1.01689375" dx="0.2" dy="1.2" layer="1"/>
+<smd name="P_GND3" x="6.353828125" y="1.1464125" dx="0.45" dy="1.45" layer="1" rot="R180"/>
+<smd name="P_GND4" x="-0.523228125" y="1.145934375" dx="0.45" dy="1.45" layer="1" rot="R180"/>
+<smd name="B12" x="5.6464375" y="1.0147875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B11" x="5.15690625" y="1.023171875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B10" x="4.644715625" y="1.020990625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B1" x="0.154653125" y="1.0185625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B2" x="0.65200625" y="1.018671875" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B3" x="1.15769375" y="1.023403125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B4" x="1.65549375" y="1.02088125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B5" x="2.155321875" y="1.01668125" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B6" x="2.65775" y="1.01414375" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B7" x="3.155375" y="1.02145" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B8" x="3.65476875" y="1.01905625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="B9" x="4.1600125" y="1.01905625" dx="0.2" dy="1.2" layer="16" rot="R180"/>
+<smd name="P_GND1" x="-0.523771875" y="1.145934375" dx="0.45" dy="1.45" layer="16"/>
+<smd name="P_GND2" x="6.339828125" y="1.145934375" dx="0.45" dy="1.45" layer="16"/>
+<polygon width="0.025" layer="1">
+<vertex x="-0.23291875" y="0.343890625"/>
+<vertex x="-0.822" y="0.348"/>
+<vertex x="-0.822" y="2.223290625"/>
+<vertex x="-0.23291875" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="0.00508125" y="1.693890625"/>
+<vertex x="0.00508125" y="0.343890625"/>
+<vertex x="0.30508125" y="0.343890625"/>
+<vertex x="0.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="0.50508125" y="1.693890625"/>
+<vertex x="0.50508125" y="0.343890625"/>
+<vertex x="0.80508125" y="0.343890625"/>
+<vertex x="0.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="1.00508125" y="1.693890625"/>
+<vertex x="1.00508125" y="0.343890625"/>
+<vertex x="1.30508125" y="0.343890625"/>
+<vertex x="1.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="1.50508125" y="1.693890625"/>
+<vertex x="1.50508125" y="0.343890625"/>
+<vertex x="1.80508125" y="0.343890625"/>
+<vertex x="1.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="2.00508125" y="1.693890625"/>
+<vertex x="2.00508125" y="0.343890625"/>
+<vertex x="2.30508125" y="0.343890625"/>
+<vertex x="2.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="2.50508125" y="1.693890625"/>
+<vertex x="2.50508125" y="0.343890625"/>
+<vertex x="2.80508125" y="0.343890625"/>
+<vertex x="2.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="3.30508125" y="0.343890625"/>
+<vertex x="3.00508125" y="0.343890625"/>
+<vertex x="3.00508125" y="1.693890625"/>
+<vertex x="3.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="3.80508125" y="0.343890625"/>
+<vertex x="3.50508125" y="0.343890625"/>
+<vertex x="3.50508125" y="1.693890625"/>
+<vertex x="3.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="4.00508125" y="1.693890625"/>
+<vertex x="4.00508125" y="0.343890625"/>
+<vertex x="4.30508125" y="0.343890625"/>
+<vertex x="4.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="4.50508125" y="1.693890625"/>
+<vertex x="4.50508125" y="0.343890625"/>
+<vertex x="4.80508125" y="0.343890625"/>
+<vertex x="4.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="5.30508125" y="0.343890625"/>
+<vertex x="5.00508125" y="0.343890625"/>
+<vertex x="5.00508125" y="1.693890625"/>
+<vertex x="5.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="5.80508125" y="0.343890625"/>
+<vertex x="5.50508125" y="0.343890625"/>
+<vertex x="5.50508125" y="1.693890625"/>
+<vertex x="5.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="1">
+<vertex x="6.04308125" y="2.223290625"/>
+<vertex x="6.04308125" y="0.343890625"/>
+<vertex x="6.62448125" y="0.343890625"/>
+<vertex x="6.62448125" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="-0.23291875" y="0.343890625"/>
+<vertex x="-0.81431875" y="0.343890625"/>
+<vertex x="-0.81431875" y="2.223290625"/>
+<vertex x="-0.23291875" y="2.223290625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="0.00508125" y="1.693890625"/>
+<vertex x="0.00508125" y="0.343890625"/>
+<vertex x="0.30508125" y="0.343890625"/>
+<vertex x="0.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="0.50508125" y="1.693890625"/>
+<vertex x="0.50508125" y="0.343890625"/>
+<vertex x="0.80508125" y="0.343890625"/>
+<vertex x="0.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="1.00508125" y="1.693890625"/>
+<vertex x="1.00508125" y="0.343890625"/>
+<vertex x="1.30508125" y="0.343890625"/>
+<vertex x="1.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="1.50508125" y="1.693890625"/>
+<vertex x="1.50508125" y="0.343890625"/>
+<vertex x="1.80508125" y="0.343890625"/>
+<vertex x="1.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="2.00508125" y="1.693890625"/>
+<vertex x="2.00508125" y="0.343890625"/>
+<vertex x="2.30508125" y="0.343890625"/>
+<vertex x="2.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="2.50508125" y="1.693890625"/>
+<vertex x="2.50508125" y="0.343890625"/>
+<vertex x="2.80508125" y="0.343890625"/>
+<vertex x="2.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="3.30508125" y="0.343890625"/>
+<vertex x="3.00508125" y="0.343890625"/>
+<vertex x="3.00508125" y="1.693890625"/>
+<vertex x="3.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="3.80508125" y="0.343890625"/>
+<vertex x="3.50508125" y="0.343890625"/>
+<vertex x="3.50508125" y="1.693890625"/>
+<vertex x="3.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="4.00508125" y="1.693890625"/>
+<vertex x="4.00508125" y="0.343890625"/>
+<vertex x="4.30508125" y="0.343890625"/>
+<vertex x="4.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="4.50508125" y="1.693890625"/>
+<vertex x="4.50508125" y="0.343890625"/>
+<vertex x="4.80508125" y="0.343890625"/>
+<vertex x="4.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="5.30508125" y="0.343890625"/>
+<vertex x="5.00508125" y="0.343890625"/>
+<vertex x="5.00508125" y="1.693890625"/>
+<vertex x="5.30508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="5.80508125" y="0.343890625"/>
+<vertex x="5.50508125" y="0.343890625"/>
+<vertex x="5.50508125" y="1.693890625"/>
+<vertex x="5.80508125" y="1.693890625"/>
+</polygon>
+<polygon width="0.025" layer="16">
+<vertex x="6.04308125" y="2.223290625"/>
+<vertex x="6.04308125" y="0.343890625"/>
+<vertex x="6.62448125" y="0.343890625"/>
+<vertex x="6.62448125" y="2.223290625"/>
+</polygon>
+<wire x1="-1.34491875" y1="1.918490625" x2="-1.34491875" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="-1.34491875" y1="0.138490625" x2="2.90508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="2.90508125" y1="0.138490625" x2="7.15508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="7.15508125" y1="1.918490625" x2="7.15508125" y2="0.138490625" width="0.025" layer="25"/>
+<wire x1="2.90508125" y1="0.138490625" x2="2.90508125" y2="3.70436875" width="0.025" layer="25"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="1"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="1"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="16"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="16"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="29"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="29"/>
+<rectangle x1="-2.32" y1="0.2718" x2="-1.044" y2="1.8378" layer="30"/>
+<rectangle x1="6.844" y1="0.29" x2="8.12" y2="1.856" layer="30"/>
+</package>
+<package name="EAST1616RGBA3-RGB-LED" urn="urn:adsk.eagle:footprint:4245357/1" library_version="78">
+<smd name="P$4" x="-0.7" y="-0.45" dx="0.7" dy="0.65" layer="1"/>
+<smd name="P$2" x="-0.7" y="0.45" dx="0.7" dy="0.65" layer="1"/>
+<smd name="P$3" x="0.7" y="-0.45" dx="0.7" dy="0.65" layer="1"/>
+<smd name="P$1" x="0.7" y="0.45" dx="0.7" dy="0.65" layer="1"/>
+<circle x="0.5" y="0" radius="0.1" width="0" layer="21"/>
+<wire x1="-0.75" y1="0.85" x2="-0.75" y2="-0.9" width="0.127" layer="51"/>
+<wire x1="-0.75" y1="-0.9" x2="0.8" y2="-0.9" width="0.127" layer="51"/>
+<wire x1="0.8" y1="-0.9" x2="0.8" y2="0.85" width="0.127" layer="51"/>
+<wire x1="0.8" y1="0.85" x2="-0.75" y2="0.85" width="0.127" layer="51"/>
+<wire x1="-0.75" y1="0.85" x2="0.8" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.8" y1="-0.9" x2="-0.75" y2="-0.9" width="0.127" layer="21"/>
+<text x="-3.15" y="1.05" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.35" y="-2.45" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="CL-505S-X-SD-T" urn="urn:adsk.eagle:footprint:4878738/6" library_version="79">
+<description>CL-505S-X-SD-T</description>
+<smd name="P$2" x="0.85" y="0.85" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$1" x="0.85" y="0" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$4" x="0" y="0" dx="0.4" dy="0.4" layer="1"/>
+<smd name="P$3" x="0" y="0.85" dx="0.4" dy="0.4" layer="1"/>
+<text x="-0.4" y="1.4" size="0.4" layer="21">&gt;NAME</text>
+<circle x="1.2990625" y="1.271121875" radius="0.1" width="0.2032" layer="21"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="R0402" urn="urn:adsk.eagle:package:4245807/8" type="model" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;RESISTOR&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="R0402"/>
+</packageinstances>
+</package3d>
+<package3d name="DX07P024AJ5R1500" urn="urn:adsk.eagle:package:5621122/11" type="model" library_version="53">
+<packageinstances>
+<packageinstance name="DX07P024AJ5R1500"/>
+</packageinstances>
+</package3d>
+<package3d name="B1,27" urn="urn:adsk.eagle:package:4245792/4" type="box" library_version="7" library_locally_modified="yes">
+<description>TEST PAD</description>
+<packageinstances>
+<packageinstance name="B1,27"/>
+</packageinstances>
+</package3d>
+<package3d name="C0402" urn="urn:adsk.eagle:package:4245806/9" type="model" library_version="93" library_locally_modified="yes">
+<description>&lt;b&gt;CAPACITOR&lt;/b&gt;</description>
+<packageinstances>
+<packageinstance name="C0402"/>
+</packageinstances>
+</package3d>
+<package3d name="QFN50P500X500X50-32" urn="urn:adsk.eagle:package:4245373/9" type="model" library_version="82">
+<description>&lt;b&gt;QFN 32&lt;/b&gt; 5 x 5 mm&lt;p&gt;
+Source: http://datasheets.maxim-ic.com/en/ds/MAX7042.pdf</description>
+<packageinstances>
+<packageinstance name="QFN32"/>
+</packageinstances>
+</package3d>
+<package3d name="DFN100X100X60-4" urn="urn:adsk.eagle:package:5621121/4" type="model" library_version="66">
+<packageinstances>
+<packageinstance name="REG_NCP114AMX330TCG"/>
+</packageinstances>
+</package3d>
+<package3d name="SOTFL50P160X60-5" urn="urn:adsk.eagle:package:5621120/4" type="model" library_version="28">
+<packageinstances>
+<packageinstance name="BZA900A"/>
+</packageinstances>
+</package3d>
+<package3d name="MLPD3X3" urn="urn:adsk.eagle:package:5825738/8" type="box" library_version="82">
+<packageinstances>
+<packageinstance name="MLPD3X3"/>
+</packageinstances>
+</package3d>
+<package3d name="WüRTH_632712000112" urn="urn:adsk.eagle:package:9339182/7" type="model" library_version="75">
+<packageinstances>
+<packageinstance name="WüRTH_632712000112"/>
+</packageinstances>
+</package3d>
+<package3d name="EAST1616RGBA3-RGB-LED" urn="urn:adsk.eagle:package:4245370/5" type="model" library_version="78">
+<packageinstances>
+<packageinstance name="EAST1616RGBA3-RGB-LED"/>
+</packageinstances>
+</package3d>
+<package3d name="CL-505S-X-SD-T" urn="urn:adsk.eagle:package:4878740/9" type="box" library_version="93" library_locally_modified="yes">
+<description>CL-505S-X-SD-T</description>
+<packageinstances>
+<packageinstance name="CL-505S-X-SD-T"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="R-EU" urn="urn:adsk.eagle:symbol:4245805/1" library_version="4" library_locally_modified="yes">
+<wire x1="-2.54" y1="-0.889" x2="2.54" y2="-0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-0.889" x2="2.54" y2="0.889" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
+<text x="-3.81" y="1.4986" size="1.778" layer="95">&gt;NAME</text>
+<text x="-3.81" y="-3.302" size="1.778" layer="96">&gt;VALUE</text>
+<text x="-5.08" y="0" size="0.4064" layer="99" align="center">SpiceOrder 1</text>
+<text x="5.08" y="0" size="0.4064" layer="99" align="center">SpiceOrder 2</text>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+</symbol>
+<symbol name="USB-C" urn="urn:adsk.eagle:symbol:4782123/2" library_version="24">
+<wire x1="-10.16" y1="15.24" x2="10.16" y2="15.24" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="10.16" y2="-22.86" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-22.86" x2="-10.16" y2="-22.86" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="-22.86" x2="-10.16" y2="15.24" width="0.254" layer="94"/>
+<pin name="SBU2" x="-15.24" y="12.7" length="middle"/>
+<pin name="SBU1" x="-15.24" y="10.16" length="middle"/>
+<pin name="TX1+" x="-15.24" y="7.62" length="middle"/>
+<pin name="TX1-" x="-15.24" y="5.08" length="middle"/>
+<pin name="RX1+" x="-15.24" y="2.54" length="middle"/>
+<pin name="RX1-" x="-15.24" y="0" length="middle"/>
+<pin name="D+" x="-15.24" y="-5.08" length="middle"/>
+<pin name="CC" x="-15.24" y="-2.54" length="middle"/>
+<pin name="RX2-" x="-15.24" y="-12.7" length="middle"/>
+<pin name="RX2+" x="-15.24" y="-15.24" length="middle"/>
+<pin name="TX2-" x="-15.24" y="-17.78" length="middle"/>
+<pin name="TX2+" x="-15.24" y="-20.32" length="middle"/>
+<pin name="VBUS" x="15.24" y="12.7" length="middle" rot="R180"/>
+<pin name="VCONN" x="15.24" y="7.62" length="middle" rot="R180"/>
+<pin name="GND" x="15.24" y="-5.08" length="middle" rot="R180"/>
+<pin name="D-" x="-15.24" y="-7.62" length="middle"/>
+<text x="-7.62" y="17.78" size="1.27" layer="95" font="vector">&gt;NAME</text>
+<text x="-10.16" y="-30.48" size="1.27" layer="96" font="vector">&gt;VALUE</text>
+</symbol>
+<symbol name="TP" urn="urn:adsk.eagle:symbol:4245791/1" library_version="3" library_locally_modified="yes">
+<wire x1="-0.762" y1="-0.762" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0.762" y2="-0.762" width="0.254" layer="94"/>
+<wire x1="0.762" y1="-0.762" x2="0" y2="-1.524" width="0.254" layer="94"/>
+<wire x1="0" y1="-1.524" x2="-0.762" y2="-0.762" width="0.254" layer="94"/>
+<text x="-1.27" y="1.27" size="1.778" layer="95">&gt;NAME</text>
+<pin name="TP" x="0" y="-2.54" visible="off" length="short" direction="in" rot="R90"/>
+</symbol>
+<symbol name="C-EU" urn="urn:adsk.eagle:symbol:4245804/1" library_version="4" library_locally_modified="yes">
+<wire x1="0" y1="0" x2="0" y2="-0.508" width="0.1524" layer="94"/>
+<wire x1="0" y1="-2.54" x2="0" y2="-2.032" width="0.1524" layer="94"/>
+<text x="1.524" y="0.381" size="1.778" layer="95">&gt;NAME</text>
+<text x="1.524" y="-4.699" size="1.778" layer="96">&gt;VALUE</text>
+<text x="0" y="2.54" size="0.4064" layer="99" align="center">SpiceOrder 1</text>
+<text x="0" y="-5.08" size="0.4064" layer="99" align="center">SpiceOrder 2</text>
+<rectangle x1="-2.032" y1="-2.032" x2="2.032" y2="-1.524" layer="94"/>
+<rectangle x1="-2.032" y1="-1.016" x2="2.032" y2="-0.508" layer="94"/>
+<pin name="1" x="0" y="2.54" visible="off" length="short" direction="pas" swaplevel="1" rot="R270"/>
+<pin name="2" x="0" y="-5.08" visible="off" length="short" direction="pas" swaplevel="1" rot="R90"/>
+</symbol>
+<symbol name="STM32L432KCU6" urn="urn:adsk.eagle:symbol:5621081/1" library_version="28">
+<pin name="VDD2" x="20.32" y="-7.62" length="middle" rot="R180"/>
+<pin name="PA8" x="20.32" y="-5.08" length="middle" rot="R180"/>
+<pin name="PA9" x="20.32" y="-2.54" length="middle" rot="R180"/>
+<pin name="PA10" x="20.32" y="0" length="middle" rot="R180"/>
+<pin name="D-" x="20.32" y="2.54" length="middle" rot="R180"/>
+<pin name="D+" x="20.32" y="5.08" length="middle" rot="R180"/>
+<pin name="SWDIO" x="20.32" y="7.62" length="middle" rot="R180"/>
+<pin name="SWCLK" x="20.32" y="10.16" length="middle" rot="R180"/>
+<pin name="PA15" x="5.08" y="25.4" length="middle" rot="R270"/>
+<pin name="PB3/SWO" x="2.54" y="25.4" length="middle" rot="R270"/>
+<pin name="PB4" x="0" y="25.4" length="middle" rot="R270"/>
+<pin name="PB5" x="-2.54" y="25.4" length="middle" rot="R270"/>
+<pin name="PB6" x="-5.08" y="25.4" length="middle" rot="R270"/>
+<pin name="PB7" x="-7.62" y="25.4" length="middle" rot="R270"/>
+<pin name="PH3/BOOT0" x="-10.16" y="25.4" length="middle" rot="R270"/>
+<pin name="VSS2" x="-12.7" y="25.4" length="middle" rot="R270"/>
+<pin name="VDD" x="-27.94" y="10.16" length="middle"/>
+<pin name="PC14" x="-27.94" y="7.62" length="middle"/>
+<pin name="PC15" x="-27.94" y="5.08" length="middle"/>
+<pin name="NRST" x="-27.94" y="2.54" length="middle"/>
+<pin name="VDDA/VREF" x="-27.94" y="0" length="middle"/>
+<pin name="PA0" x="-27.94" y="-2.54" length="middle"/>
+<pin name="PA1" x="-27.94" y="-5.08" length="middle"/>
+<pin name="PA2" x="-27.94" y="-7.62" length="middle"/>
+<pin name="PA3" x="-12.7" y="-22.86" length="middle" rot="R90"/>
+<pin name="PA4" x="-10.16" y="-22.86" length="middle" rot="R90"/>
+<pin name="PA5" x="-7.62" y="-22.86" length="middle" rot="R90"/>
+<pin name="PA6" x="-5.08" y="-22.86" length="middle" rot="R90"/>
+<pin name="PA7" x="-2.54" y="-22.86" length="middle" rot="R90"/>
+<pin name="PB0" x="0" y="-22.86" length="middle" rot="R90"/>
+<pin name="PB1" x="2.54" y="-22.86" length="middle" rot="R90"/>
+<pin name="VSS" x="5.08" y="-22.86" length="middle" rot="R90"/>
+<pin name="VSS3" x="-15.24" y="25.4" length="middle" rot="R270"/>
+<wire x1="15.24" y1="-7.62" x2="15.24" y2="-17.78" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-17.78" x2="-22.86" y2="-17.78" width="0.254" layer="94"/>
+<wire x1="-22.86" y1="-17.78" x2="-22.86" y2="20.32" width="0.254" layer="94"/>
+<wire x1="-22.86" y1="20.32" x2="15.24" y2="20.32" width="0.254" layer="94"/>
+<wire x1="15.24" y1="20.32" x2="15.24" y2="-7.62" width="0.254" layer="94"/>
+<text x="-7.62" y="30.48" size="1.27" layer="95">&gt;NAME</text>
+<text x="-7.62" y="-27.94" size="1.27" layer="96">&gt;VALUE</text>
+<circle x="-20.066" y="17.526" radius="1.077628125" width="0.254" layer="94"/>
+</symbol>
+<symbol name="NCP114AMX330TCG" urn="urn:adsk.eagle:symbol:5621078/1" library_version="28">
+<wire x1="-10.16" y1="5.08" x2="10.16" y2="5.08" width="0.254" layer="94"/>
+<wire x1="10.16" y1="5.08" x2="10.16" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-5.08" x2="-10.16" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="-5.08" x2="-10.16" y2="5.08" width="0.254" layer="94"/>
+<text x="-10.1869" y="5.09345" size="1.782709375" layer="95">&gt;NAME</text>
+<text x="-10.1915" y="-7.643659375" size="1.78353125" layer="96">&gt;VALUE</text>
+<pin name="OUT" x="15.24" y="2.54" length="middle" direction="out" rot="R180"/>
+<pin name="GND" x="15.24" y="0" length="middle" direction="pwr" rot="R180"/>
+<pin name="EN" x="-15.24" y="-2.54" length="middle" direction="in"/>
+<pin name="IN" x="-15.24" y="2.54" length="middle" direction="in"/>
+<pin name="EPAD" x="15.24" y="-2.54" length="middle" direction="pas" rot="R180"/>
+</symbol>
+<symbol name="D-ZENERS" urn="urn:adsk.eagle:symbol:5621075/1" library_version="28">
+<wire x1="-1.27" y1="-1.905" x2="1.27" y2="0" width="0.254" layer="94"/>
+<wire x1="1.27" y1="0" x2="-1.27" y2="1.905" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="1.905" x2="-1.27" y2="-1.905" width="0.254" layer="94"/>
+<wire x1="1.397" y1="1.905" x2="1.397" y2="-1.905" width="0.254" layer="94"/>
+<wire x1="1.397" y1="-1.905" x2="2.032" y2="-1.905" width="0.254" layer="94"/>
+<wire x1="1.397" y1="1.905" x2="0.762" y2="1.905" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="3.175" x2="1.27" y2="5.08" width="0.254" layer="94"/>
+<wire x1="1.27" y1="5.08" x2="-1.27" y2="6.985" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="6.985" x2="-1.27" y2="3.175" width="0.254" layer="94"/>
+<wire x1="1.397" y1="6.985" x2="1.397" y2="3.175" width="0.254" layer="94"/>
+<wire x1="1.397" y1="3.175" x2="2.032" y2="3.175" width="0.254" layer="94"/>
+<wire x1="1.397" y1="6.985" x2="0.762" y2="6.985" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="-6.985" x2="1.27" y2="-5.08" width="0.254" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="-1.27" y2="-3.175" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="-3.175" x2="-1.27" y2="-6.985" width="0.254" layer="94"/>
+<wire x1="1.397" y1="-3.175" x2="1.397" y2="-6.985" width="0.254" layer="94"/>
+<wire x1="1.397" y1="-6.985" x2="2.032" y2="-6.985" width="0.254" layer="94"/>
+<wire x1="1.397" y1="-3.175" x2="0.762" y2="-3.175" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="8.255" x2="1.27" y2="10.16" width="0.254" layer="94"/>
+<wire x1="1.27" y1="10.16" x2="-1.27" y2="12.065" width="0.254" layer="94"/>
+<wire x1="-1.27" y1="12.065" x2="-1.27" y2="8.255" width="0.254" layer="94"/>
+<wire x1="1.397" y1="12.065" x2="1.397" y2="8.255" width="0.254" layer="94"/>
+<wire x1="1.397" y1="8.255" x2="2.032" y2="8.255" width="0.254" layer="94"/>
+<wire x1="1.397" y1="12.065" x2="0.762" y2="12.065" width="0.254" layer="94"/>
+<wire x1="0" y1="-5.08" x2="-2.54" y2="-5.08" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="-2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="5.08" x2="-2.54" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="0" y1="10.16" x2="-2.54" y2="10.16" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="10.16" x2="-5.08" y2="10.16" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="10.16" x2="-5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-5.08" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="-5.08" x2="-2.54" y2="-5.08" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="0" x2="-5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="5.08" x2="-2.54" y2="5.08" width="0.1524" layer="94"/>
+<text x="-2.9464" y="15.3416" size="1.778" layer="95">&gt;NAME</text>
+<text x="-4.4704" y="-12.1158" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="C" x="2.54" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="C1" x="2.54" y="5.08" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="C2" x="2.54" y="-5.08" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="C3" x="2.54" y="10.16" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="P$1" x="-10.16" y="2.54" visible="pad" length="middle"/>
+</symbol>
+<symbol name="AS3956" urn="urn:adsk.eagle:symbol:5825726/2" library_version="53">
+<wire x1="-10.16" y1="12.7" x2="10.16" y2="12.7" width="0.254" layer="94"/>
+<wire x1="10.16" y1="12.7" x2="10.16" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-12.7" x2="-10.16" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="-12.7" x2="-10.16" y2="12.7" width="0.254" layer="94"/>
+<pin name="VP_IO" x="-15.24" y="10.16" length="middle"/>
+<pin name="VP_REG" x="-15.24" y="5.08" length="middle"/>
+<pin name="LC1" x="-15.24" y="0" length="middle"/>
+<pin name="LC2" x="-15.24" y="-5.08" length="middle"/>
+<pin name="VSS" x="-15.24" y="-10.16" length="middle"/>
+<pin name="SS" x="15.24" y="-10.16" length="middle" rot="R180"/>
+<pin name="SCLK" x="15.24" y="-5.08" length="middle" rot="R180"/>
+<pin name="MOSI" x="15.24" y="0" length="middle" rot="R180"/>
+<pin name="MISO" x="15.24" y="5.08" length="middle" rot="R180"/>
+<pin name="IRQ" x="15.24" y="10.16" length="middle" rot="R180"/>
+<text x="-5.08" y="15.24" size="1.778" layer="95">&gt;NAME</text>
+<text x="-5.08" y="-17.78" size="1.778" layer="96">&gt;VALUE</text>
+</symbol>
+<symbol name="LED-RGB" urn="urn:adsk.eagle:symbol:4245364/1" library_version="78">
+<wire x1="6.35" y1="1.778" x2="5.08" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-0.254" x2="3.81" y2="1.778" width="0.254" layer="94"/>
+<wire x1="6.35" y1="-0.254" x2="5.08" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-0.254" x2="3.81" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="6.35" y1="1.778" x2="3.81" y2="1.778" width="0.254" layer="94"/>
+<wire x1="3.048" y1="1.524" x2="2.159" y2="0.635" width="0.1524" layer="94"/>
+<wire x1="3.81" y1="0.762" x2="2.921" y2="-0.127" width="0.1524" layer="94"/>
+<wire x1="1.27" y1="1.778" x2="0" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="0" y1="-0.254" x2="-1.27" y2="1.778" width="0.254" layer="94"/>
+<wire x1="1.27" y1="-0.254" x2="0" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="0" y1="-0.254" x2="-1.27" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="1.27" y1="1.778" x2="-1.27" y2="1.778" width="0.254" layer="94"/>
+<wire x1="-2.032" y1="1.524" x2="-2.921" y2="0.635" width="0.1524" layer="94"/>
+<wire x1="-1.27" y1="0.762" x2="-2.159" y2="-0.127" width="0.1524" layer="94"/>
+<wire x1="-3.81" y1="1.778" x2="-5.08" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-0.254" x2="-6.35" y2="1.778" width="0.254" layer="94"/>
+<wire x1="-3.81" y1="-0.254" x2="-5.08" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-0.254" x2="-6.35" y2="-0.254" width="0.254" layer="94"/>
+<wire x1="-3.81" y1="1.778" x2="-6.35" y2="1.778" width="0.254" layer="94"/>
+<wire x1="-7.112" y1="1.524" x2="-8.001" y2="0.635" width="0.1524" layer="94"/>
+<wire x1="-6.35" y1="0.762" x2="-7.239" y2="-0.127" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="2.54" x2="0" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="0" y1="2.54" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="2.54" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="0" width="0.1524" layer="94"/>
+<circle x="-5.08" y="2.54" radius="0.1796" width="0.254" layer="94"/>
+<circle x="0" y="2.54" radius="0.1796" width="0.254" layer="94"/>
+<text x="-2.54" y="3.302" size="1.778" layer="95">&gt;NAME</text>
+<text x="-2.54" y="5.461" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="CGREEN" x="5.08" y="-2.54" visible="pad" length="short" direction="pas" rot="R90"/>
+<pin name="CBLUE" x="0" y="-2.54" visible="pad" length="short" direction="pas" rot="R90"/>
+<pin name="CRED" x="-5.08" y="-2.54" visible="pad" length="short" direction="pas" rot="R90"/>
+<pin name="A2" x="-5.08" y="5.08" visible="pad" length="middle" direction="pas" rot="R270"/>
+<polygon width="0.1524" layer="94">
+<vertex x="2.032" y="1.016"/>
+<vertex x="1.778" y="0.254"/>
+<vertex x="2.54" y="0.508"/>
+</polygon>
+<polygon width="0.1524" layer="94">
+<vertex x="2.794" y="0.254"/>
+<vertex x="2.54" y="-0.508"/>
+<vertex x="3.302" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="94">
+<vertex x="-3.048" y="1.016"/>
+<vertex x="-3.302" y="0.254"/>
+<vertex x="-2.54" y="0.508"/>
+</polygon>
+<polygon width="0.1524" layer="94">
+<vertex x="-2.286" y="0.254"/>
+<vertex x="-2.54" y="-0.508"/>
+<vertex x="-1.778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="94">
+<vertex x="-8.128" y="1.016"/>
+<vertex x="-8.382" y="0.254"/>
+<vertex x="-7.62" y="0.508"/>
+</polygon>
+<polygon width="0.1524" layer="94">
+<vertex x="-7.366" y="0.254"/>
+<vertex x="-7.62" y="-0.508"/>
+<vertex x="-6.858" y="-0.254"/>
+</polygon>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="RESISTOR" urn="urn:adsk.eagle:component:4245809/7" prefix="R" library_version="93" library_locally_modified="yes">
+<gates>
+<gate name="G$1" symbol="R-EU" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="R0402">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4245807/8"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DX07P024AJ5R1500" urn="urn:adsk.eagle:component:5621126/18" prefix="USBC" library_version="75">
+<gates>
+<gate name="G$1" symbol="USB-C" x="0" y="2.54"/>
+</gates>
+<devices>
+<device name="" package="DX07P024AJ5R1500">
+<connects>
+<connect gate="G$1" pin="CC" pad="A5"/>
+<connect gate="G$1" pin="D+" pad="A6"/>
+<connect gate="G$1" pin="D-" pad="A7"/>
+<connect gate="G$1" pin="GND" pad="A1 A12 B1 B12 P_GND3 P_GND4"/>
+<connect gate="G$1" pin="RX1+" pad="B11"/>
+<connect gate="G$1" pin="RX1-" pad="B10"/>
+<connect gate="G$1" pin="RX2+" pad="A11"/>
+<connect gate="G$1" pin="RX2-" pad="A10"/>
+<connect gate="G$1" pin="SBU1" pad="A8"/>
+<connect gate="G$1" pin="SBU2" pad="B8"/>
+<connect gate="G$1" pin="TX1+" pad="A2"/>
+<connect gate="G$1" pin="TX1-" pad="A3"/>
+<connect gate="G$1" pin="TX2+" pad="B2"/>
+<connect gate="G$1" pin="TX2-" pad="B3"/>
+<connect gate="G$1" pin="VBUS" pad="A4 A9 B4 B9"/>
+<connect gate="G$1" pin="VCONN" pad="B5"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5621122/11"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="WURTH" package="WüRTH_632712000112">
+<connects>
+<connect gate="G$1" pin="CC" pad="A5"/>
+<connect gate="G$1" pin="D+" pad="A6"/>
+<connect gate="G$1" pin="D-" pad="A7"/>
+<connect gate="G$1" pin="GND" pad="A1 A12 B1 B12 P_GND1 P_GND2 P_GND3 P_GND4"/>
+<connect gate="G$1" pin="RX1+" pad="B11"/>
+<connect gate="G$1" pin="RX1-" pad="B10"/>
+<connect gate="G$1" pin="RX2+" pad="A11"/>
+<connect gate="G$1" pin="RX2-" pad="A10"/>
+<connect gate="G$1" pin="SBU1" pad="A8"/>
+<connect gate="G$1" pin="SBU2" pad="B8"/>
+<connect gate="G$1" pin="TX1+" pad="A2"/>
+<connect gate="G$1" pin="TX1-" pad="A3"/>
+<connect gate="G$1" pin="TX2+" pad="B2"/>
+<connect gate="G$1" pin="TX2-" pad="B3"/>
+<connect gate="G$1" pin="VBUS" pad="A4 A9 B4 B9"/>
+<connect gate="G$1" pin="VCONN" pad="B5"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:9339182/7"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TEST_POINT" urn="urn:adsk.eagle:component:4245793/3" prefix="T" library_version="8" library_locally_modified="yes">
+<gates>
+<gate name="G$1" symbol="TP" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="B1,27">
+<connects>
+<connect gate="G$1" pin="TP" pad="TP"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="CAPACITOR" urn="urn:adsk.eagle:component:4245808/7" prefix="C" library_version="93" library_locally_modified="yes">
+<gates>
+<gate name="G$1" symbol="C-EU" x="0" y="2.54"/>
+</gates>
+<devices>
+<device name="" package="C0402">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4245806/9"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="STM32L432KCU6" urn="urn:adsk.eagle:component:5621128/7" prefix="ST" library_version="82">
+<gates>
+<gate name="G$1" symbol="STM32L432KCU6" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="QFN32">
+<connects>
+<connect gate="G$1" pin="D+" pad="22"/>
+<connect gate="G$1" pin="D-" pad="21"/>
+<connect gate="G$1" pin="NRST" pad="4"/>
+<connect gate="G$1" pin="PA0" pad="6"/>
+<connect gate="G$1" pin="PA1" pad="7"/>
+<connect gate="G$1" pin="PA10" pad="20"/>
+<connect gate="G$1" pin="PA15" pad="25"/>
+<connect gate="G$1" pin="PA2" pad="8"/>
+<connect gate="G$1" pin="PA3" pad="9"/>
+<connect gate="G$1" pin="PA4" pad="10"/>
+<connect gate="G$1" pin="PA5" pad="11"/>
+<connect gate="G$1" pin="PA6" pad="12"/>
+<connect gate="G$1" pin="PA7" pad="13"/>
+<connect gate="G$1" pin="PA8" pad="18"/>
+<connect gate="G$1" pin="PA9" pad="19"/>
+<connect gate="G$1" pin="PB0" pad="14"/>
+<connect gate="G$1" pin="PB1" pad="15"/>
+<connect gate="G$1" pin="PB3/SWO" pad="26"/>
+<connect gate="G$1" pin="PB4" pad="27"/>
+<connect gate="G$1" pin="PB5" pad="28"/>
+<connect gate="G$1" pin="PB6" pad="29"/>
+<connect gate="G$1" pin="PB7" pad="30"/>
+<connect gate="G$1" pin="PC14" pad="2"/>
+<connect gate="G$1" pin="PC15" pad="3"/>
+<connect gate="G$1" pin="PH3/BOOT0" pad="31"/>
+<connect gate="G$1" pin="SWCLK" pad="24"/>
+<connect gate="G$1" pin="SWDIO" pad="23"/>
+<connect gate="G$1" pin="VDD" pad="1"/>
+<connect gate="G$1" pin="VDD2" pad="17"/>
+<connect gate="G$1" pin="VDDA/VREF" pad="5"/>
+<connect gate="G$1" pin="VSS" pad="16"/>
+<connect gate="G$1" pin="VSS2" pad="32"/>
+<connect gate="G$1" pin="VSS3" pad="EXP"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4245373/9"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="NCP114AMX330TCG" urn="urn:adsk.eagle:component:5621125/4" prefix="L" library_version="66">
+<description>CMOS Low Dropout Regulator, 300 mA 3.3V, Active Discharge</description>
+<gates>
+<gate name="G$1" symbol="NCP114AMX330TCG" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="REG_NCP114AMX330TCG">
+<connects>
+<connect gate="G$1" pin="EN" pad="3"/>
+<connect gate="G$1" pin="EPAD" pad="5"/>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="4"/>
+<connect gate="G$1" pin="OUT" pad="1"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5621121/4"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="AVAILABILITY" value="Unavailable"/>
+<attribute name="DESCRIPTION" value=" CMOS Low Dropout Regulator _LDO_, 300 mA 3.3V, Active Discharge "/>
+<attribute name="MF" value="ON Semiconductor"/>
+<attribute name="MP" value="NCP114AMX330TCG"/>
+<attribute name="PACKAGE" value="UDFN-4 ON Semiconductor"/>
+<attribute name="PRICE" value="None"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="BZA900A-ESD-ZENERS" urn="urn:adsk.eagle:component:5621124/4" prefix="Z" library_version="28">
+<gates>
+<gate name="G$1" symbol="D-ZENERS" x="5.08" y="-2.54"/>
+</gates>
+<devices>
+<device name="" package="BZA900A">
+<connects>
+<connect gate="G$1" pin="C" pad="P$1"/>
+<connect gate="G$1" pin="C1" pad="P$5"/>
+<connect gate="G$1" pin="C2" pad="P$4"/>
+<connect gate="G$1" pin="C3" pad="P$3"/>
+<connect gate="G$1" pin="P$1" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5621120/4"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="AMS3956" urn="urn:adsk.eagle:component:5825739/10" prefix="N" library_version="82">
+<gates>
+<gate name="G$1" symbol="AS3956" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="MLPD3X3">
+<connects>
+<connect gate="G$1" pin="IRQ" pad="P10"/>
+<connect gate="G$1" pin="LC1" pad="P3"/>
+<connect gate="G$1" pin="LC2" pad="P4"/>
+<connect gate="G$1" pin="MISO" pad="P9"/>
+<connect gate="G$1" pin="MOSI" pad="P8"/>
+<connect gate="G$1" pin="SCLK" pad="P7"/>
+<connect gate="G$1" pin="SS" pad="P6"/>
+<connect gate="G$1" pin="VP_IO" pad="P1"/>
+<connect gate="G$1" pin="VP_REG" pad="P2"/>
+<connect gate="G$1" pin="VSS" pad="P$11 P5"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5825738/8"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="RGB_LED_1X1" urn="urn:adsk.eagle:component:4245376/12" prefix="L" library_version="93" library_locally_modified="yes">
+<description>EAST1616RGBA3</description>
+<gates>
+<gate name="G$1" symbol="LED-RGB" x="0" y="-2.54"/>
+</gates>
+<devices>
+<device name="" package="EAST1616RGBA3-RGB-LED">
+<connects>
+<connect gate="G$1" pin="A2" pad="P$3"/>
+<connect gate="G$1" pin="CBLUE" pad="P$1"/>
+<connect gate="G$1" pin="CGREEN" pad="P$2"/>
+<connect gate="G$1" pin="CRED" pad="P$4"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4245370/5"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="MPN" value="123t" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="CL-505S-X-SD-T" package="CL-505S-X-SD-T">
+<connects>
+<connect gate="G$1" pin="A2" pad="P$4"/>
+<connect gate="G$1" pin="CBLUE" pad="P$1"/>
+<connect gate="G$1" pin="CGREEN" pad="P$3"/>
+<connect gate="G$1" pin="CRED" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:4878740/9"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="ultra_librarian">
+<packages>
+<package name="RC0402N">
+<smd name="1" x="-0.556" y="0" dx="0.6548" dy="0.508" layer="1"/>
+<smd name="2" x="0.556" y="0" dx="0.6548" dy="0.508" layer="1"/>
+<wire x1="-1.143" y1="-0.508" x2="-1.143" y2="0.508" width="0.1524" layer="39"/>
+<wire x1="-1.143" y1="0.508" x2="1.143" y2="0.508" width="0.1524" layer="39"/>
+<wire x1="1.143" y1="0.508" x2="1.143" y2="-0.508" width="0.1524" layer="39"/>
+<wire x1="1.143" y1="-0.508" x2="-1.143" y2="-0.508" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-1.1374" y="-0.508"/>
+<vertex x="-1.1374" y="0.508"/>
+<vertex x="1.1374" y="0.508"/>
+<vertex x="1.1374" y="-0.508"/>
+</polygon>
+<wire x1="-0.2286" y1="-0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="0.254" x2="-0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="-0.254" x2="-0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="-0.254" x2="0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="0.254" x2="0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="-0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="-0.254" x2="0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="0.254" x2="-0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.2032"/>
+<vertex x="0.1778" y="0.2032"/>
+<vertex x="0.1778" y="-0.2032"/>
+<vertex x="-0.1778" y="-0.2032"/>
+</polygon>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="RC0402N-M">
+<smd name="1" x="-0.656" y="0" dx="0.8548" dy="0.608" layer="1"/>
+<smd name="2" x="0.656" y="0" dx="0.8548" dy="0.608" layer="1"/>
+<wire x1="-1.6002" y1="-0.8128" x2="-1.6002" y2="0.8128" width="0.1524" layer="39"/>
+<wire x1="-1.6002" y1="0.8128" x2="1.6002" y2="0.8128" width="0.1524" layer="39"/>
+<wire x1="1.6002" y1="0.8128" x2="1.6002" y2="-0.8128" width="0.1524" layer="39"/>
+<wire x1="1.6002" y1="-0.8128" x2="-1.6002" y2="-0.8128" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-1.5914" y="-0.812"/>
+<vertex x="-1.5914" y="0.812"/>
+<vertex x="1.5914" y="0.812"/>
+<vertex x="1.5914" y="-0.812"/>
+</polygon>
+<wire x1="-0.2286" y1="-0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="0.254" x2="-0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="-0.254" x2="-0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="-0.254" x2="0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="0.254" x2="0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="-0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="-0.254" x2="0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="0.254" x2="-0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.2032"/>
+<vertex x="0.1778" y="0.2032"/>
+<vertex x="0.1778" y="-0.2032"/>
+<vertex x="-0.1778" y="-0.2032"/>
+</polygon>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+<package name="RC0402N-L">
+<smd name="1" x="-0.456" y="0" dx="0.4548" dy="0.408" layer="1"/>
+<smd name="2" x="0.456" y="0" dx="0.4548" dy="0.408" layer="1"/>
+<wire x1="-0.7874" y1="-0.3048" x2="-0.7874" y2="0.3048" width="0.1524" layer="39"/>
+<wire x1="-0.7874" y1="0.3048" x2="0.7874" y2="0.3048" width="0.1524" layer="39"/>
+<wire x1="0.7874" y1="0.3048" x2="0.7874" y2="-0.3048" width="0.1524" layer="39"/>
+<wire x1="0.7874" y1="-0.3048" x2="-0.7874" y2="-0.3048" width="0.1524" layer="39"/>
+<polygon width="0.1524" layer="39">
+<vertex x="-0.785" y="-0.3056"/>
+<vertex x="-0.785" y="0.3056"/>
+<vertex x="0.785" y="0.3056"/>
+<vertex x="0.785" y="-0.3056"/>
+</polygon>
+<wire x1="-0.2286" y1="-0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="0.254" x2="-0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="-0.254" x2="-0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="-0.254" x2="0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="0.254" x2="0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.2286" y1="-0.254" x2="0.2286" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="0.5334" y1="-0.254" x2="0.5334" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="0.2286" y1="0.254" x2="-0.2286" y2="0.254" width="0.1524" layer="51"/>
+<wire x1="-0.5334" y1="0.254" x2="-0.5334" y2="-0.254" width="0.1524" layer="51"/>
+<wire x1="-0.254" y1="0" x2="0.254" y2="0" width="0.1524" layer="23"/>
+<wire x1="0" y1="-0.254" x2="0" y2="0.254" width="0.1524" layer="23"/>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.254"/>
+<vertex x="0.1778" y="0.254"/>
+<vertex x="0.1778" y="-0.254"/>
+<vertex x="-0.1778" y="-0.254"/>
+</polygon>
+<polygon width="0.1524" layer="41">
+<vertex x="-0.1778" y="0.2032"/>
+<vertex x="0.1778" y="0.2032"/>
+<vertex x="0.1778" y="-0.2032"/>
+<vertex x="-0.1778" y="-0.2032"/>
+</polygon>
+<text x="-3.2766" y="-0.635" size="1.27" layer="25" ratio="6" rot="SR0">&gt;Name</text>
+</package>
+</packages>
+<symbols>
+<symbol name="RES">
+<pin name="2" x="0" y="0" visible="pin" length="short" direction="pas" swaplevel="1"/>
+<pin name="1" x="12.7" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<wire x1="3.175" y1="1.27" x2="4.445" y2="-1.27" width="0.2032" layer="94"/>
+<wire x1="4.445" y1="-1.27" x2="5.715" y2="1.27" width="0.2032" layer="94"/>
+<wire x1="5.715" y1="1.27" x2="6.985" y2="-1.27" width="0.2032" layer="94"/>
+<wire x1="6.985" y1="-1.27" x2="8.255" y2="1.27" width="0.2032" layer="94"/>
+<wire x1="8.255" y1="1.27" x2="9.525" y2="-1.27" width="0.2032" layer="94"/>
+<wire x1="2.54" y1="0" x2="3.175" y2="1.27" width="0.2032" layer="94"/>
+<wire x1="9.525" y1="-1.27" x2="10.16" y2="0" width="0.2032" layer="94"/>
+<text x="-2.6162" y="-5.5372" size="3.4798" layer="96" ratio="10" rot="SR0">&gt;Value</text>
+<text x="-2.1844" y="2.0828" size="3.4798" layer="95" ratio="10" rot="SR0">&gt;Name</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="RC0402FR-071KL" prefix="R">
+<gates>
+<gate name="A" symbol="RES" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="RC0402N">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="RC0402FR071KL" constant="no"/>
+<attribute name="VENDOR" value="Yageo" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="RC0402N-M" package="RC0402N-M">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="RC0402FR071KL" constant="no"/>
+<attribute name="VENDOR" value="Yageo" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="RC0402N-L" package="RC0402N-L">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MANUFACTURER_PART_NUMBER" value="RC0402FR071KL" constant="no"/>
+<attribute name="VENDOR" value="Yageo" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="GRM2195C1H103FA01D">
+<packages>
+<package name="CAPC2012X95N">
+<text x="-1.66" y="-1.02" size="0.5" layer="27" align="top-left">&gt;VALUE</text>
+<text x="-1.66" y="1.02" size="0.5" layer="25">&gt;NAME</text>
+<wire x1="1.05" y1="-0.68" x2="-1.05" y2="-0.68" width="0.127" layer="51"/>
+<wire x1="1.05" y1="0.68" x2="-1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="1.05" y1="-0.68" x2="1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="-1.05" y1="-0.68" x2="-1.05" y2="0.68" width="0.127" layer="51"/>
+<wire x1="-1.665" y1="-0.94" x2="1.665" y2="-0.94" width="0.05" layer="39"/>
+<wire x1="-1.665" y1="0.94" x2="1.665" y2="0.94" width="0.05" layer="39"/>
+<wire x1="-1.665" y1="-0.94" x2="-1.665" y2="0.94" width="0.05" layer="39"/>
+<wire x1="1.665" y1="-0.94" x2="1.665" y2="0.94" width="0.05" layer="39"/>
+<smd name="1" x="-0.888" y="0" dx="1.05" dy="1.38" layer="1"/>
+<smd name="2" x="0.888" y="0" dx="1.05" dy="1.38" layer="1"/>
+</package>
+</packages>
+<symbols>
+<symbol name="GRM2195C1H103FA01D">
+<text x="0" y="3.81093125" size="1.77843125" layer="95">&gt;NAME</text>
+<text x="0" y="-5.08848125" size="1.78096875" layer="96">&gt;VALUE</text>
+<rectangle x1="0" y1="-1.906859375" x2="0.635" y2="1.905" layer="94"/>
+<rectangle x1="1.90685" y1="-1.90685" x2="2.54" y2="1.905" layer="94"/>
+<pin name="2" x="5.08" y="0" visible="pad" length="short" direction="pas" rot="R180"/>
+<pin name="1" x="-2.54" y="0" visible="pad" length="short" direction="pas"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="GRM2195C1H103FA01D" prefix="C">
+<description>.01UF 50V 1% 0805</description>
+<gates>
+<gate name="G$1" symbol="GRM2195C1H103FA01D" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="CAPC2012X95N">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DESCRIPTION" value=" Multilayer Ceramic Capacitor, GRM Series, 0.01 F, 1%, C0G / NP0, 50 V, 0805 [2012 Metric] "/>
+<attribute name="DIGI-KEY_PART_NUMBER" value="490-8295-1-ND"/>
+<attribute name="DIGI-KEY_PURCHASE_URL" value="https://www.digikey.com/product-detail/en/murata-electronics/GRM2195C1H103FA01D/490-8295-1-ND/4380589?utm_source=snapeda&amp;utm_medium=aggregator&amp;utm_campaign=symbol"/>
+<attribute name="MF" value="Murata"/>
+<attribute name="MP" value="GRM2195C1H103FA01D"/>
+<attribute name="PACKAGE" value="2012 Murata"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0.1524" drill="0.2032">
+<clearance class="0" value="0.1016"/>
+</class>
+</classes>
+<parts>
+<part name="USBC1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="DX07P024AJ5R1500" device="WURTH" package3d_urn="urn:adsk.eagle:package:9339182/7" value="DX07P024AJ5R1500WURTH"/>
+<part name="R2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="RESISTOR" device="" package3d_urn="urn:adsk.eagle:package:4245807/8" value="5k"/>
+<part name="SUPPLY2" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="P+1" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+5V" device=""/>
+<part name="SUPPLY3" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="C1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u"/>
+<part name="SUPPLY1" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="P+2" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+5V" device=""/>
+<part name="C2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="SUPPLY4" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="C4" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u"/>
+<part name="C5" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="+3V1" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="P+3" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+5V" device=""/>
+<part name="SUPPLY5" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="+3V2" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="GND2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="TEST_POINT" device="" package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+<part name="+5V2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="TEST_POINT" device="" package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+<part name="3V2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="TEST_POINT" device="" package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+<part name="SWDIO2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="TEST_POINT" device="" package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+<part name="SWCLK2" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="TEST_POINT" device="" package3d_urn="urn:adsk.eagle:package:4245792/4"/>
+<part name="R1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="RESISTOR" device="" package3d_urn="urn:adsk.eagle:package:4245807/8" value="175"/>
+<part name="+3V3" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="SUPPLY7" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="+3V4" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="SUPPLY8" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="C6" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value=".1u"/>
+<part name="C13" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="SUPPLY9" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="ST1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="STM32L432KCU6" device="" package3d_urn="urn:adsk.eagle:package:4245373/9"/>
+<part name="L3" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="NCP114AMX330TCG" device="" package3d_urn="urn:adsk.eagle:package:5621121/4"/>
+<part name="Z1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="BZA900A-ESD-ZENERS" device="" package3d_urn="urn:adsk.eagle:package:5621120/4"/>
+<part name="P+4" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+5V" device=""/>
+<part name="SUPPLY19" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="+3V5" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="+3V6" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="+3V7" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="N1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="AMS3956" device="" package3d_urn="urn:adsk.eagle:package:5825738/8"/>
+<part name="SUPPLY20" library="supply2" library_urn="urn:adsk.eagle:library:372" deviceset="PE" device="" value="GND"/>
+<part name="+3V8" library="supply1" library_urn="urn:adsk.eagle:library:371" deviceset="+3V3" device=""/>
+<part name="C15" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="12p"/>
+<part name="C14" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="33p"/>
+<part name="C3" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="C7" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="C8" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="C9" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="CAPACITOR" device="" package3d_urn="urn:adsk.eagle:package:4245806/9" value="4.7u"/>
+<part name="L1" library="efm-fido" library_urn="urn:adsk.eagle:library:4245354" deviceset="RGB_LED_1X1" device="CL-505S-X-SD-T" package3d_urn="urn:adsk.eagle:package:4878740/9"/>
+<part name="R25" library="ultra_librarian" deviceset="RC0402FR-071KL" device="RC0402N-L" value="1k"/>
+<part name="R26" library="ultra_librarian" deviceset="RC0402FR-071KL" device="RC0402N-L" value="1k"/>
+<part name="C23" library="GRM2195C1H103FA01D" deviceset="GRM2195C1H103FA01D" device="" value="10nF"/>
+</parts>
+<sheets>
+<sheet>
+<plain>
+</plain>
+<instances>
+<instance part="USBC1" gate="G$1" x="-35.56" y="12.7" smashed="yes">
+<attribute name="NAME" x="-43.18" y="30.48" size="1.27" layer="95" font="vector"/>
+<attribute name="VALUE" x="-43.18" y="-15.24" size="1.27" layer="96" font="vector"/>
+</instance>
+<instance part="R2" gate="G$1" x="-76.2" y="12.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="-72.39" y="11.2014" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="-72.39" y="16.002" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY2" gate="PE" x="-91.44" y="12.7" smashed="yes" rot="R270">
+<attribute name="VALUE" x="-96.139" y="17.145" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="P+1" gate="1" x="-10.16" y="25.4" smashed="yes" rot="R270">
+<attribute name="VALUE" x="-10.16" y="27.94" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="SUPPLY3" gate="PE" x="-10.16" y="7.62" smashed="yes" rot="R90">
+<attribute name="VALUE" x="-5.461" y="3.175" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C1" gate="G$1" x="38.1" y="-43.18" smashed="yes" rot="R180">
+<attribute name="NAME" x="36.576" y="-43.561" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="36.576" y="-38.481" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY1" gate="PE" x="83.82" y="38.1" smashed="yes" rot="R180">
+<attribute name="VALUE" x="88.265" y="42.799" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="P+2" gate="1" x="27.94" y="-30.48" smashed="yes">
+<attribute name="VALUE" x="25.4" y="-30.48" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C2" gate="G$1" x="45.72" y="-43.18" smashed="yes" rot="R180">
+<attribute name="NAME" x="44.196" y="-43.561" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="44.196" y="-38.481" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY4" gate="PE" x="43.18" y="-30.48" smashed="yes" rot="R180">
+<attribute name="VALUE" x="47.625" y="-25.781" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C4" gate="G$1" x="81.28" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="79.756" y="25.019" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="79.756" y="30.099" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C5" gate="G$1" x="88.9" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="87.376" y="25.019" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="87.376" y="30.099" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="+3V1" gate="G$1" x="101.6" y="-96.52" smashed="yes">
+<attribute name="VALUE" x="104.14" y="-93.98" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="P+3" gate="1" x="91.44" y="-96.52" smashed="yes">
+<attribute name="VALUE" x="93.98" y="-93.98" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY5" gate="PE" x="81.28" y="-99.06" smashed="yes" rot="R180">
+<attribute name="VALUE" x="85.725" y="-94.361" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="+3V2" gate="G$1" x="200.66" y="7.62" smashed="yes" rot="R270">
+<attribute name="VALUE" x="195.58" y="10.16" size="1.778" layer="96"/>
+</instance>
+<instance part="GND2" gate="G$1" x="81.28" y="-109.22" smashed="yes" rot="R180">
+<attribute name="NAME" x="82.55" y="-110.49" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="+5V2" gate="G$1" x="91.44" y="-109.22" smashed="yes" rot="R180">
+<attribute name="NAME" x="92.71" y="-110.49" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="3V2" gate="G$1" x="101.6" y="-109.22" smashed="yes" rot="R180">
+<attribute name="NAME" x="102.87" y="-110.49" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="SWDIO2" gate="G$1" x="147.32" y="-109.22" smashed="yes" rot="R180">
+<attribute name="NAME" x="148.59" y="-110.49" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="SWCLK2" gate="G$1" x="160.02" y="-109.22" smashed="yes" rot="R180">
+<attribute name="NAME" x="161.29" y="-110.49" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="R1" gate="G$1" x="187.96" y="7.62" smashed="yes">
+<attribute name="NAME" x="184.15" y="9.1186" size="1.778" layer="95"/>
+<attribute name="VALUE" x="184.15" y="4.318" size="1.778" layer="96"/>
+</instance>
+<instance part="+3V3" gate="G$1" x="86.36" y="-43.18" smashed="yes">
+<attribute name="VALUE" x="83.82" y="-48.26" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="SUPPLY7" gate="PE" x="86.36" y="-66.04" smashed="yes">
+<attribute name="VALUE" x="81.915" y="-70.739" size="1.778" layer="96"/>
+</instance>
+<instance part="+3V4" gate="G$1" x="71.12" y="12.7" smashed="yes" rot="R90">
+<attribute name="VALUE" x="76.2" y="10.16" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY8" gate="PE" x="190.5" y="-22.86" smashed="yes" rot="R90">
+<attribute name="VALUE" x="195.199" y="-27.305" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C6" gate="G$1" x="167.64" y="-20.32" smashed="yes" rot="R90">
+<attribute name="NAME" x="167.259" y="-18.796" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="172.339" y="-18.796" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C13" gate="G$1" x="167.64" y="-27.94" smashed="yes" rot="R90">
+<attribute name="NAME" x="167.259" y="-26.416" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="172.339" y="-26.416" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="SUPPLY9" gate="PE" x="147.32" y="-45.72" smashed="yes" rot="R90">
+<attribute name="VALUE" x="152.019" y="-50.165" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="ST1" gate="G$1" x="116.84" y="-12.7" smashed="yes" rot="R180">
+<attribute name="NAME" x="144.78" y="7.62" size="1.27" layer="95" rot="R180"/>
+<attribute name="VALUE" x="149.86" y="10.16" size="1.27" layer="96" rot="R180"/>
+</instance>
+<instance part="L3" gate="G$1" x="66.04" y="-55.88" smashed="yes">
+<attribute name="NAME" x="55.8531" y="-50.78655" size="1.782709375" layer="95"/>
+<attribute name="VALUE" x="55.8485" y="-63.523659375" size="1.78353125" layer="96"/>
+</instance>
+<instance part="Z1" gate="G$1" x="205.74" y="-48.26" smashed="yes" rot="R180">
+<attribute name="NAME" x="208.6864" y="-63.6016" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="217.8304" y="-36.1442" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="P+4" gate="1" x="190.5" y="-45.72" smashed="yes">
+<attribute name="VALUE" x="187.96" y="-45.72" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY19" gate="PE" x="223.52" y="-53.34" smashed="yes">
+<attribute name="VALUE" x="219.075" y="-58.039" size="1.778" layer="96"/>
+</instance>
+<instance part="+3V5" gate="G$1" x="190.5" y="-53.34" smashed="yes" rot="R90">
+<attribute name="VALUE" x="195.58" y="-55.88" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="+3V6" gate="G$1" x="160.02" y="-55.88" smashed="yes" rot="R180">
+<attribute name="VALUE" x="162.56" y="-50.8" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="+3V7" gate="G$1" x="132.08" y="-58.42" smashed="yes" rot="R180">
+<attribute name="VALUE" x="134.62" y="-53.34" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="N1" gate="G$1" x="162.56" y="38.1" smashed="yes" rot="R180">
+<attribute name="NAME" x="167.64" y="22.86" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="167.64" y="55.88" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY20" gate="PE" x="190.5" y="58.42" smashed="yes" rot="R180">
+<attribute name="VALUE" x="194.945" y="63.119" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="+3V8" gate="G$1" x="198.12" y="20.32" smashed="yes" rot="R180">
+<attribute name="VALUE" x="200.66" y="25.4" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="C15" gate="G$1" x="220.98" y="43.18" smashed="yes" rot="R180">
+<attribute name="NAME" x="219.456" y="42.799" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="219.456" y="47.879" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C14" gate="G$1" x="228.6" y="43.18" smashed="yes" rot="R180">
+<attribute name="NAME" x="227.076" y="42.799" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="227.076" y="47.879" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C3" gate="G$1" x="167.64" y="-35.56" smashed="yes" rot="R90">
+<attribute name="NAME" x="167.259" y="-34.036" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="172.339" y="-34.036" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C7" gate="G$1" x="167.64" y="-43.18" smashed="yes" rot="R90">
+<attribute name="NAME" x="167.259" y="-41.656" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="172.339" y="-41.656" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C8" gate="G$1" x="96.52" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="94.996" y="25.019" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="94.996" y="30.099" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="C9" gate="G$1" x="104.14" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="102.616" y="25.019" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="102.616" y="30.099" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="L1" gate="G$1" x="170.18" y="2.54" smashed="yes" rot="R270">
+<attribute name="NAME" x="173.482" y="5.08" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="175.641" y="5.08" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="R25" gate="A" x="104.14" y="-43.18" smashed="yes" rot="R180">
+<attribute name="VALUE" x="106.7562" y="-40.1828" size="1.6764" layer="96" ratio="10" rot="SR180"/>
+<attribute name="NAME" x="106.3244" y="-45.2628" size="1.778" layer="95" ratio="10" rot="SR180"/>
+</instance>
+<instance part="R26" gate="A" x="104.14" y="-58.42" smashed="yes" rot="R180">
+<attribute name="VALUE" x="106.7562" y="-55.4228" size="1.6764" layer="96" ratio="10" rot="SR180"/>
+<attribute name="NAME" x="106.3244" y="-60.5028" size="1.6764" layer="95" ratio="10" rot="SR180"/>
+</instance>
+<instance part="C23" gate="G$1" x="111.76" y="-71.12" smashed="yes">
+<attribute name="NAME" x="111.76" y="-67.30906875" size="1.77843125" layer="95"/>
+<attribute name="VALUE" x="111.76" y="-76.20848125" size="1.78096875" layer="96"/>
+</instance>
+</instances>
+<busses>
+</busses>
+<nets>
+<net name="+5V" class="0">
+<segment>
+<pinref part="USBC1" gate="G$1" pin="VBUS"/>
+<pinref part="P+1" gate="1" pin="+5V"/>
+<wire x1="-20.32" y1="25.4" x2="-12.7" y2="25.4" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="P+2" gate="1" pin="+5V"/>
+<wire x1="27.94" y1="-33.02" x2="27.94" y2="-50.8" width="0.1524" layer="91"/>
+<pinref part="C2" gate="G$1" pin="1"/>
+<wire x1="45.72" y1="-45.72" x2="45.72" y2="-50.8" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="-50.8" x2="38.1" y2="-50.8" width="0.1524" layer="91"/>
+<pinref part="C1" gate="G$1" pin="1"/>
+<wire x1="38.1" y1="-50.8" x2="27.94" y2="-50.8" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="-45.72" x2="38.1" y2="-50.8" width="0.1524" layer="91"/>
+<junction x="38.1" y="-50.8"/>
+<wire x1="50.8" y1="-53.34" x2="45.72" y2="-53.34" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="-53.34" x2="45.72" y2="-50.8" width="0.1524" layer="91"/>
+<junction x="45.72" y="-50.8"/>
+<wire x1="50.8" y1="-58.42" x2="45.72" y2="-58.42" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="-58.42" x2="45.72" y2="-53.34" width="0.1524" layer="91"/>
+<junction x="45.72" y="-53.34"/>
+<pinref part="L3" gate="G$1" pin="IN"/>
+<pinref part="L3" gate="G$1" pin="EN"/>
+</segment>
+<segment>
+<pinref part="P+3" gate="1" pin="+5V"/>
+<wire x1="91.44" y1="-106.68" x2="91.44" y2="-99.06" width="0.1524" layer="91"/>
+<pinref part="+5V2" gate="G$1" pin="TP"/>
+</segment>
+<segment>
+<pinref part="Z1" gate="G$1" pin="C"/>
+<pinref part="P+4" gate="1" pin="+5V"/>
+<wire x1="203.2" y1="-48.26" x2="190.5" y2="-48.26" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="PE" class="0">
+<segment>
+<pinref part="R2" gate="G$1" pin="2"/>
+<wire x1="-81.28" y1="12.7" x2="-88.9" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="SUPPLY2" gate="PE" pin="PE"/>
+</segment>
+<segment>
+<pinref part="SUPPLY3" gate="PE" pin="PE"/>
+<pinref part="USBC1" gate="G$1" pin="GND"/>
+<wire x1="-12.7" y1="7.62" x2="-20.32" y2="7.62" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="SUPPLY4" gate="PE" pin="PE"/>
+<wire x1="43.18" y1="-33.02" x2="43.18" y2="-35.56" width="0.1524" layer="91"/>
+<pinref part="C1" gate="G$1" pin="2"/>
+<wire x1="43.18" y1="-35.56" x2="38.1" y2="-35.56" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="-35.56" x2="38.1" y2="-38.1" width="0.1524" layer="91"/>
+<pinref part="C2" gate="G$1" pin="2"/>
+<wire x1="45.72" y1="-38.1" x2="45.72" y2="-35.56" width="0.1524" layer="91"/>
+<wire x1="45.72" y1="-35.56" x2="43.18" y2="-35.56" width="0.1524" layer="91"/>
+<junction x="43.18" y="-35.56"/>
+</segment>
+<segment>
+<pinref part="C5" gate="G$1" pin="2"/>
+<wire x1="88.9" y1="30.48" x2="88.9" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="33.02" x2="83.82" y2="33.02" width="0.1524" layer="91"/>
+<pinref part="C4" gate="G$1" pin="2"/>
+<wire x1="83.82" y1="33.02" x2="81.28" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="33.02" x2="81.28" y2="30.48" width="0.1524" layer="91"/>
+<pinref part="SUPPLY1" gate="PE" pin="PE"/>
+<wire x1="83.82" y1="35.56" x2="83.82" y2="33.02" width="0.1524" layer="91"/>
+<junction x="83.82" y="33.02"/>
+<wire x1="111.76" y1="10.16" x2="111.76" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="12.7" x2="111.76" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="33.02" x2="104.14" y2="33.02" width="0.1524" layer="91"/>
+<junction x="88.9" y="33.02"/>
+<pinref part="ST1" gate="G$1" pin="VSS"/>
+<pinref part="C8" gate="G$1" pin="2"/>
+<wire x1="104.14" y1="33.02" x2="96.52" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="33.02" x2="88.9" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="30.48" x2="96.52" y2="33.02" width="0.1524" layer="91"/>
+<junction x="96.52" y="33.02"/>
+<pinref part="C9" gate="G$1" pin="2"/>
+<wire x1="104.14" y1="30.48" x2="104.14" y2="33.02" width="0.1524" layer="91"/>
+<junction x="104.14" y="33.02"/>
+<pinref part="ST1" gate="G$1" pin="PB1"/>
+<wire x1="114.3" y1="10.16" x2="114.3" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="114.3" y1="12.7" x2="111.76" y2="12.7" width="0.1524" layer="91"/>
+<junction x="111.76" y="12.7"/>
+<label x="111.76" y="15.24" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="SUPPLY5" gate="PE" pin="PE"/>
+<wire x1="81.28" y1="-106.68" x2="81.28" y2="-101.6" width="0.1524" layer="91"/>
+<pinref part="GND2" gate="G$1" pin="TP"/>
+</segment>
+<segment>
+<pinref part="SUPPLY7" gate="PE" pin="PE"/>
+<wire x1="86.36" y1="-55.88" x2="86.36" y2="-63.5" width="0.1524" layer="91"/>
+<pinref part="L3" gate="G$1" pin="GND"/>
+<wire x1="81.28" y1="-55.88" x2="86.36" y2="-55.88" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C13" gate="G$1" pin="2"/>
+<wire x1="172.72" y1="-27.94" x2="175.26" y2="-27.94" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="-27.94" x2="175.26" y2="-22.86" width="0.1524" layer="91"/>
+<pinref part="C6" gate="G$1" pin="2"/>
+<wire x1="175.26" y1="-22.86" x2="175.26" y2="-20.32" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="-20.32" x2="172.72" y2="-20.32" width="0.1524" layer="91"/>
+<pinref part="SUPPLY8" gate="PE" pin="PE"/>
+<wire x1="187.96" y1="-22.86" x2="175.26" y2="-22.86" width="0.1524" layer="91"/>
+<junction x="175.26" y="-22.86"/>
+<pinref part="C3" gate="G$1" pin="2"/>
+<wire x1="172.72" y1="-35.56" x2="175.26" y2="-35.56" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="-35.56" x2="175.26" y2="-27.94" width="0.1524" layer="91"/>
+<junction x="175.26" y="-27.94"/>
+<pinref part="C7" gate="G$1" pin="2"/>
+<wire x1="172.72" y1="-43.18" x2="175.26" y2="-43.18" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="-43.18" x2="175.26" y2="-35.56" width="0.1524" layer="91"/>
+<junction x="175.26" y="-35.56"/>
+</segment>
+<segment>
+<wire x1="132.08" y1="-38.1" x2="132.08" y2="-45.72" width="0.1524" layer="91"/>
+<pinref part="SUPPLY9" gate="PE" pin="PE"/>
+<wire x1="132.08" y1="-45.72" x2="144.78" y2="-45.72" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="-38.1" x2="129.54" y2="-45.72" width="0.1524" layer="91"/>
+<wire x1="129.54" y1="-45.72" x2="132.08" y2="-45.72" width="0.1524" layer="91"/>
+<junction x="132.08" y="-45.72"/>
+<pinref part="ST1" gate="G$1" pin="VSS2"/>
+<pinref part="ST1" gate="G$1" pin="VSS3"/>
+</segment>
+<segment>
+<pinref part="SUPPLY19" gate="PE" pin="PE"/>
+<pinref part="Z1" gate="G$1" pin="P$1"/>
+<wire x1="223.52" y1="-50.8" x2="215.9" y2="-50.8" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="N1" gate="G$1" pin="VSS"/>
+<wire x1="177.8" y1="48.26" x2="190.5" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="190.5" y1="48.26" x2="190.5" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="SUPPLY20" gate="PE" pin="PE"/>
+</segment>
+<segment>
+<pinref part="ST1" gate="G$1" pin="PA8"/>
+<wire x1="96.52" y1="-7.62" x2="93.98" y2="-7.62" width="0.1524" layer="91"/>
+<label x="91.44" y="-7.62" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="C23" gate="G$1" pin="2"/>
+<wire x1="116.84" y1="-71.12" x2="121.92" y2="-71.12" width="0.1524" layer="91"/>
+<label x="121.92" y="-71.12" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="D+" class="0">
+<segment>
+<wire x1="-78.74" y1="2.54" x2="-93.98" y2="2.54" width="0.1524" layer="91"/>
+<label x="-96.52" y="2.54" size="1.778" layer="95" rot="R270"/>
+<wire x1="-78.74" y1="2.54" x2="-78.74" y2="7.62" width="0.1524" layer="91"/>
+<wire x1="-78.74" y1="7.62" x2="-50.8" y2="7.62" width="0.1524" layer="91"/>
+<pinref part="USBC1" gate="G$1" pin="D+"/>
+</segment>
+<segment>
+<wire x1="63.5" y1="-12.7" x2="63.5" y2="-2.54" width="0.1524" layer="91"/>
+<label x="63.5" y="-2.54" size="1.778" layer="95"/>
+<pinref part="ST1" gate="G$1" pin="D+"/>
+<wire x1="96.52" y1="-17.78" x2="63.5" y2="-17.78" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="-17.78" x2="63.5" y2="-12.7" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<wire x1="198.12" y1="-58.42" x2="198.12" y2="-76.2" width="0.1524" layer="91"/>
+<label x="198.12" y="-76.2" size="1.778" layer="95" rot="R180"/>
+<pinref part="Z1" gate="G$1" pin="C3"/>
+<wire x1="198.12" y1="-58.42" x2="203.2" y2="-58.42" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="D-" class="0">
+<segment>
+<wire x1="-76.2" y1="-5.08" x2="-93.98" y2="-5.08" width="0.1524" layer="91"/>
+<label x="-96.52" y="-5.08" size="1.778" layer="95" rot="R270"/>
+<pinref part="USBC1" gate="G$1" pin="D-"/>
+<wire x1="-50.8" y1="5.08" x2="-76.2" y2="5.08" width="0.1524" layer="91"/>
+<wire x1="-76.2" y1="5.08" x2="-76.2" y2="-5.08" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<wire x1="71.12" y1="-12.7" x2="71.12" y2="-2.54" width="0.1524" layer="91"/>
+<label x="71.12" y="-2.54" size="1.778" layer="95"/>
+<pinref part="ST1" gate="G$1" pin="D-"/>
+<wire x1="96.52" y1="-15.24" x2="71.12" y2="-15.24" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="-15.24" x2="71.12" y2="-12.7" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<wire x1="195.58" y1="-43.18" x2="195.58" y2="-30.48" width="0.1524" layer="91"/>
+<label x="195.58" y="-30.48" size="1.778" layer="95"/>
+<pinref part="Z1" gate="G$1" pin="C2"/>
+<wire x1="203.2" y1="-43.18" x2="195.58" y2="-43.18" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$1" class="0">
+<segment>
+<pinref part="USBC1" gate="G$1" pin="CC"/>
+<wire x1="-58.42" y1="10.16" x2="-50.8" y2="10.16" width="0.1524" layer="91"/>
+<pinref part="R2" gate="G$1" pin="1"/>
+<wire x1="-71.12" y1="12.7" x2="-58.42" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="-58.42" y1="12.7" x2="-58.42" y2="10.16" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="+3V3" class="0">
+<segment>
+<pinref part="+3V1" gate="G$1" pin="+3V3"/>
+<wire x1="101.6" y1="-106.68" x2="101.6" y2="-99.06" width="0.1524" layer="91"/>
+<pinref part="3V2" gate="G$1" pin="TP"/>
+</segment>
+<segment>
+<pinref part="+3V2" gate="G$1" pin="+3V3"/>
+<wire x1="193.04" y1="7.62" x2="198.12" y2="7.62" width="0.1524" layer="91"/>
+<pinref part="R1" gate="G$1" pin="2"/>
+</segment>
+<segment>
+<pinref part="+3V3" gate="G$1" pin="+3V3"/>
+<wire x1="81.28" y1="-53.34" x2="86.36" y2="-53.34" width="0.1524" layer="91"/>
+<wire x1="86.36" y1="-53.34" x2="86.36" y2="-45.72" width="0.1524" layer="91"/>
+<pinref part="L3" gate="G$1" pin="OUT"/>
+</segment>
+<segment>
+<wire x1="88.9" y1="12.7" x2="83.82" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="C5" gate="G$1" pin="1"/>
+<wire x1="83.82" y1="12.7" x2="81.28" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="88.9" y1="22.86" x2="88.9" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="C4" gate="G$1" pin="1"/>
+<wire x1="81.28" y1="22.86" x2="81.28" y2="12.7" width="0.1524" layer="91"/>
+<pinref part="+3V4" gate="G$1" pin="+3V3"/>
+<wire x1="73.66" y1="12.7" x2="81.28" y2="12.7" width="0.1524" layer="91"/>
+<junction x="81.28" y="12.7"/>
+<wire x1="96.52" y1="-5.08" x2="83.82" y2="-5.08" width="0.1524" layer="91"/>
+<wire x1="83.82" y1="-5.08" x2="83.82" y2="12.7" width="0.1524" layer="91"/>
+<junction x="83.82" y="12.7"/>
+<pinref part="ST1" gate="G$1" pin="VDD2"/>
+<pinref part="C8" gate="G$1" pin="1"/>
+<wire x1="96.52" y1="22.86" x2="96.52" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="12.7" x2="88.9" y2="12.7" width="0.1524" layer="91"/>
+<junction x="88.9" y="12.7"/>
+<pinref part="C9" gate="G$1" pin="1"/>
+<wire x1="104.14" y1="22.86" x2="104.14" y2="12.7" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="12.7" x2="96.52" y2="12.7" width="0.1524" layer="91"/>
+<junction x="96.52" y="12.7"/>
+</segment>
+<segment>
+<pinref part="C13" gate="G$1" pin="1"/>
+<wire x1="165.1" y1="-27.94" x2="160.02" y2="-27.94" width="0.1524" layer="91"/>
+<pinref part="C6" gate="G$1" pin="1"/>
+<wire x1="165.1" y1="-20.32" x2="160.02" y2="-20.32" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="-20.32" x2="160.02" y2="-22.86" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="-22.86" x2="160.02" y2="-27.94" width="0.1524" layer="91"/>
+<wire x1="144.78" y1="-22.86" x2="160.02" y2="-22.86" width="0.1524" layer="91"/>
+<junction x="160.02" y="-22.86"/>
+<wire x1="144.78" y1="-12.7" x2="160.02" y2="-12.7" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="-12.7" x2="160.02" y2="-20.32" width="0.1524" layer="91"/>
+<junction x="160.02" y="-20.32"/>
+<pinref part="ST1" gate="G$1" pin="VDD"/>
+<pinref part="ST1" gate="G$1" pin="VDDA/VREF"/>
+<pinref part="+3V6" gate="G$1" pin="+3V3"/>
+<wire x1="160.02" y1="-53.34" x2="160.02" y2="-43.18" width="0.1524" layer="91"/>
+<junction x="160.02" y="-27.94"/>
+<pinref part="C3" gate="G$1" pin="1"/>
+<wire x1="160.02" y1="-43.18" x2="160.02" y2="-35.56" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="-35.56" x2="160.02" y2="-27.94" width="0.1524" layer="91"/>
+<wire x1="165.1" y1="-35.56" x2="160.02" y2="-35.56" width="0.1524" layer="91"/>
+<junction x="160.02" y="-35.56"/>
+<pinref part="C7" gate="G$1" pin="1"/>
+<wire x1="165.1" y1="-43.18" x2="160.02" y2="-43.18" width="0.1524" layer="91"/>
+<junction x="160.02" y="-43.18"/>
+</segment>
+<segment>
+<pinref part="+3V5" gate="G$1" pin="+3V3"/>
+<pinref part="Z1" gate="G$1" pin="C1"/>
+<wire x1="193.04" y1="-53.34" x2="203.2" y2="-53.34" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="ST1" gate="G$1" pin="PH3/BOOT0"/>
+<wire x1="127" y1="-38.1" x2="127" y2="-53.34" width="0.1524" layer="91"/>
+<pinref part="+3V7" gate="G$1" pin="+3V3"/>
+<wire x1="127" y1="-53.34" x2="132.08" y2="-53.34" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="-53.34" x2="132.08" y2="-55.88" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="N1" gate="G$1" pin="VP_REG"/>
+<wire x1="177.8" y1="33.02" x2="198.12" y2="33.02" width="0.1524" layer="91"/>
+<pinref part="+3V8" gate="G$1" pin="+3V3"/>
+<wire x1="198.12" y1="22.86" x2="198.12" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="198.12" y1="27.94" x2="198.12" y2="33.02" width="0.1524" layer="91"/>
+<junction x="198.12" y="27.94"/>
+<pinref part="N1" gate="G$1" pin="VP_IO"/>
+<wire x1="177.8" y1="27.94" x2="198.12" y2="27.94" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$2" class="0">
+<segment>
+<wire x1="182.88" y1="7.62" x2="175.26" y2="7.62" width="0.1524" layer="91"/>
+<pinref part="R1" gate="G$1" pin="1"/>
+<pinref part="L1" gate="G$1" pin="A2"/>
+</segment>
+</net>
+<net name="SWCLK" class="0">
+<segment>
+<wire x1="160.02" y1="-106.68" x2="160.02" y2="-96.52" width="0.1524" layer="91"/>
+<label x="160.02" y="-96.52" size="1.778" layer="95"/>
+<pinref part="SWCLK2" gate="G$1" pin="TP"/>
+</segment>
+<segment>
+<pinref part="ST1" gate="G$1" pin="SWCLK"/>
+<wire x1="96.52" y1="-22.86" x2="91.44" y2="-22.86" width="0.1524" layer="91"/>
+<label x="83.82" y="-25.4" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SWDIO" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="SWDIO"/>
+<wire x1="96.52" y1="-20.32" x2="91.44" y2="-20.32" width="0.1524" layer="91"/>
+<label x="81.28" y="-22.86" size="1.778" layer="95"/>
+</segment>
+<segment>
+<wire x1="147.32" y1="-106.68" x2="147.32" y2="-96.52" width="0.1524" layer="91"/>
+<label x="147.32" y="-96.52" size="1.778" layer="95"/>
+<pinref part="SWDIO2" gate="G$1" pin="TP"/>
+</segment>
+</net>
+<net name="N$3" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PA2"/>
+<wire x1="154.94" y1="-5.08" x2="144.78" y2="-5.08" width="0.1524" layer="91"/>
+<wire x1="154.94" y1="-5.08" x2="154.94" y2="7.62" width="0.1524" layer="91"/>
+<pinref part="L1" gate="G$1" pin="CRED"/>
+<wire x1="154.94" y1="7.62" x2="167.64" y2="7.62" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$4" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PA3"/>
+<wire x1="129.54" y1="15.24" x2="129.54" y2="10.16" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="15.24" x2="129.54" y2="15.24" width="0.1524" layer="91"/>
+<pinref part="L1" gate="G$1" pin="CBLUE"/>
+<wire x1="149.86" y1="15.24" x2="149.86" y2="2.54" width="0.1524" layer="91"/>
+<wire x1="149.86" y1="2.54" x2="167.64" y2="2.54" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$5" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PA1"/>
+<wire x1="144.78" y1="-7.62" x2="160.02" y2="-7.62" width="0.1524" layer="91"/>
+<pinref part="L1" gate="G$1" pin="CGREEN"/>
+<wire x1="167.64" y1="-2.54" x2="160.02" y2="-2.54" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="-2.54" x2="160.02" y2="-7.62" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SCLK" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="SCLK"/>
+<pinref part="ST1" gate="G$1" pin="PA5"/>
+<wire x1="147.32" y1="43.18" x2="124.46" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="43.18" x2="124.46" y2="10.16" width="0.1524" layer="91"/>
+<label x="129.54" y="43.18" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="MOSI" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="MOSI"/>
+<pinref part="ST1" gate="G$1" pin="PA7"/>
+<wire x1="147.32" y1="38.1" x2="119.38" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="38.1" x2="119.38" y2="10.16" width="0.1524" layer="91"/>
+<label x="129.54" y="38.1" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="MISO" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="MISO"/>
+<pinref part="ST1" gate="G$1" pin="PA6"/>
+<wire x1="147.32" y1="33.02" x2="121.92" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="121.92" y1="33.02" x2="121.92" y2="10.16" width="0.1524" layer="91"/>
+<label x="129.54" y="33.02" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="AMS_CS1" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="SS"/>
+<pinref part="ST1" gate="G$1" pin="PB0"/>
+<wire x1="116.84" y1="10.16" x2="116.84" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="48.26" x2="147.32" y2="48.26" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$8" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="LC2"/>
+<wire x1="177.8" y1="43.18" x2="203.2" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="43.18" x2="203.2" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="50.8" x2="220.98" y2="50.8" width="0.1524" layer="91"/>
+<pinref part="C15" gate="G$1" pin="2"/>
+<wire x1="220.98" y1="48.26" x2="220.98" y2="50.8" width="0.1524" layer="91"/>
+<junction x="220.98" y="50.8"/>
+<wire x1="220.98" y1="50.8" x2="228.6" y2="50.8" width="0.1524" layer="91"/>
+<pinref part="C14" gate="G$1" pin="2"/>
+<wire x1="228.6" y1="50.8" x2="228.6" y2="48.26" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$9" class="0">
+<segment>
+<pinref part="N1" gate="G$1" pin="LC1"/>
+<wire x1="177.8" y1="38.1" x2="203.2" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="38.1" x2="203.2" y2="35.56" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="35.56" x2="220.98" y2="35.56" width="0.1524" layer="91"/>
+<pinref part="C15" gate="G$1" pin="1"/>
+<wire x1="220.98" y1="35.56" x2="220.98" y2="40.64" width="0.1524" layer="91"/>
+<wire x1="220.98" y1="35.56" x2="220.98" y2="33.02" width="0.1524" layer="91"/>
+<junction x="220.98" y="35.56"/>
+<pinref part="C14" gate="G$1" pin="1"/>
+<wire x1="220.98" y1="33.02" x2="228.6" y2="33.02" width="0.1524" layer="91"/>
+<wire x1="228.6" y1="33.02" x2="228.6" y2="40.64" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="AMS_IRQ" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PC15"/>
+<wire x1="144.78" y1="-17.78" x2="147.32" y2="-17.78" width="0.1524" layer="91"/>
+<label x="147.32" y="-17.78" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="N1" gate="G$1" pin="IRQ"/>
+<wire x1="147.32" y1="27.94" x2="139.7" y2="27.94" width="0.1524" layer="91"/>
+<label x="139.7" y="25.4" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="S$5" class="0">
+<segment>
+<pinref part="C23" gate="G$1" pin="1"/>
+<wire x1="109.22" y1="-71.12" x2="109.22" y2="-58.42" width="0.1524" layer="91"/>
+<wire x1="109.22" y1="-58.42" x2="121.92" y2="-58.42" width="0.1524" layer="91"/>
+<pinref part="ST1" gate="G$1" pin="PB6"/>
+<wire x1="121.92" y1="-58.42" x2="121.92" y2="-38.1" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="S$2" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PB5"/>
+<wire x1="104.14" y1="-48.26" x2="119.38" y2="-48.26" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="-48.26" x2="119.38" y2="-38.1" width="0.1524" layer="91"/>
+<pinref part="R26" gate="A" pin="2"/>
+<wire x1="104.14" y1="-48.26" x2="104.14" y2="-58.42" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="S$4" class="0">
+<segment>
+<pinref part="ST1" gate="G$1" pin="PB4"/>
+<wire x1="116.84" y1="-43.18" x2="116.84" y2="-38.1" width="0.1524" layer="91"/>
+<pinref part="R25" gate="A" pin="2"/>
+<wire x1="104.14" y1="-43.18" x2="116.84" y2="-43.18" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="T2" class="0">
+<segment>
+<pinref part="R25" gate="A" pin="1"/>
+<wire x1="91.44" y1="-43.18" x2="91.44" y2="-50.8" width="0.1524" layer="91"/>
+<label x="91.44" y="-50.8" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="T1" class="0">
+<segment>
+<pinref part="R26" gate="A" pin="1"/>
+<wire x1="91.44" y1="-58.42" x2="91.44" y2="-63.5" width="0.1524" layer="91"/>
+<label x="91.44" y="-63.5" size="1.778" layer="95"/>
+</segment>
+</net>
+</nets>
+</sheet>
+</sheets>
+<errors>
+<approved hash="104,1,81.28,-55.88,L3,GND,PE,,,"/>
+<approved hash="208,1,101.6,-99.06,+3V3,sup,,,,"/>
+<approved hash="208,1,198.12,7.62,+3V3,sup,,,,"/>
+<approved hash="208,1,86.36,-45.72,+3V3,sup,,,,"/>
+<approved hash="208,1,81.28,-53.34,+3V3,out,,,,"/>
+<approved hash="208,1,73.66,12.7,+3V3,sup,,,,"/>
+<approved hash="208,1,160.02,-53.34,+3V3,sup,,,,"/>
+<approved hash="208,1,193.04,-53.34,+3V3,sup,,,,"/>
+<approved hash="208,1,132.08,-55.88,+3V3,sup,,,,"/>
+<approved hash="208,1,198.12,22.86,+3V3,sup,,,,"/>
+<approved hash="106,1,91.44,-58.42,T1,,,,,"/>
+<approved hash="106,1,91.44,-43.18,T2,,,,,"/>
+</errors>
+</schematic>
+</drawing>
+<compatibility>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>


### PR DESCRIPTION
- Removes the dome button
- Adds a capacitive touch key protruding from each side of the board
- Removes the test pad connected to PB6
- Connects those touch keys via 1k resistors to PB4 and PB5
- Adds a 10nF sampling cap and connects it to PB6 and GND

See also solokeys/solo#342.